### PR TITLE
feat: TypeScript rewrite — full IDB API adoption with tests and tooling (closes #1, #2, #4, #5, #6, #7, #8)

### DIFF
--- a/.continue/agents/new-config.yaml
+++ b/.continue/agents/new-config.yaml
@@ -1,0 +1,23 @@
+# This is an example configuration file
+# To learn more, see the full config.yaml reference: https://docs.continue.dev/reference
+
+name: Example Config
+version: 1.0.0
+schema: v1
+
+# Define which models can be used
+# https://docs.continue.dev/customization/models
+models:
+  - name: my gpt-5
+    provider: openai
+    model: gpt-5
+    apiKey: YOUR_OPENAI_API_KEY_HERE
+  - uses: ollama/qwen2.5-coder-7b
+  - uses: anthropic/claude-4-sonnet
+    with:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+
+# MCP Servers that Continue can access
+# https://docs.continue.dev/customization/mcp-tools
+mcpServers:
+  - uses: anthropic/memory-mcp

--- a/.continue/mcpServers/new-mcp-server.yaml
+++ b/.continue/mcpServers/new-mcp-server.yaml
@@ -1,0 +1,10 @@
+name: New MCP server
+version: 0.0.1
+schema: v1
+mcpServers:
+  - name: New MCP server
+    command: npx
+    args:
+      - -y
+      - <your-mcp-server>
+    env: {}

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,3 @@
+node_modules
+dist
+coverage

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,0 +1,37 @@
+module.exports = {
+  root: true,
+  env: {
+    node: true,
+    es2022: true,
+  },
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    project: './tsconfig.eslint.json',
+    tsconfigRootDir: __dirname,
+    sourceType: 'module',
+  },
+  plugins: ['@typescript-eslint'],
+  extends: ['airbnb-base', 'airbnb-typescript/base', 'prettier'],
+  settings: {
+    'import/resolver': {
+      typescript: {
+        project: './tsconfig.json',
+      },
+    },
+  },
+  rules: {
+    'import/extensions': [
+      'error',
+      'ignorePackages',
+      {
+        ts: 'never',
+        js: 'never',
+      },
+    ],
+    'import/prefer-default-export': 'off',
+    '@typescript-eslint/no-use-before-define': [
+      'error',
+      { functions: false, classes: true, variables: true, typedefs: true },
+    ],
+  },
+};

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -33,5 +33,24 @@ module.exports = {
       'error',
       { functions: false, classes: true, variables: true, typedefs: true },
     ],
+    'max-classes-per-file': ['error', { max: 1, ignoreExpressions: true }],
   },
+  overrides: [
+    {
+      files: ['*.d.ts'],
+      rules: {
+        'max-classes-per-file': 'off',
+      },
+    },
+    {
+      files: ['tests/**/*.ts'],
+      rules: {
+        'max-classes-per-file': 'off',
+        'no-underscore-dangle': 'off',
+        'class-methods-use-this': 'off',
+        '@typescript-eslint/no-dupe-class-members': 'off',
+        '@typescript-eslint/no-unused-vars': 'off',
+      },
+    },
+  ],
 };

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,3 @@
+node_modules
+dist
+coverage

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,7 @@
+{
+  "singleQuote": true,
+  "semi": true,
+  "trailingComma": "all",
+  "printWidth": 100,
+  "tabWidth": 2
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,13 +2,18 @@
 
 ## Project Overview
 
-TypeScript library providing promise-based and async iterator utilities for the IndexedDB API. Private package, no external runtime dependencies.
+TypeScript library providing promise-based and async iterator utilities for the IndexedDB API.
+Private package, no external runtime dependencies.
+
+**Open PR:** https://github.com/0xDazzer/indexeddb/pull/21
+**Upstream:** https://github.com/0xDazzer/indexeddb
+**Fork:** https://github.com/inc198107/indexeddb (branch: `my_ideal_branch`)
 
 ## Tech Stack
 
 - **Language:** TypeScript 5.7 (strict mode, ES2022 target, ESNext modules)
 - **Runtime:** Browser (DOM lib) + Node.js types
-- **Test runner:** Node.js built-in `node:test` via `tsx`
+- **Test runner:** Node.js built-in `node:test` via `tsx` (53 tests, 0 failures)
 - **Linter:** ESLint 8 (airbnb-base + airbnb-typescript/base + prettier)
 - **Formatter:** Prettier 3
 - **Package manager:** npm (v3 lockfile)
@@ -16,69 +21,165 @@ TypeScript library providing promise-based and async iterator utilities for the 
 ## Key Commands
 
 ```bash
-npm test          # Run all tests via tsx --test
-npm run lint      # Check linting
+npm test          # Run all 53 tests via tsx --test
+npm run lint      # Check linting (airbnb + TS rules)
 npm run lint:fix  # Auto-fix linting issues
 npm run format    # Format with Prettier
 ```
 
-## Code Conventions
+## Available Skills (slash commands)
 
-### Prettier (enforced)
-- Single quotes (`'`)
-- Semicolons: yes
-- Trailing commas: all
-- Print width: 100 chars
-- Tab width: 2 spaces
-
-### ESLint rules
-- **No default exports** — use named exports only
-- Max 1 class per file (class expressions allowed)
-- Import extensions disabled for `.ts`/`.js` files
-- `no-use-before-define` allows function declarations
-
-### TypeScript
-- Strict mode (`"strict": true`)
-- `noEmit: true` — no compiled output, types only
-- `moduleResolution: "Bundler"`
-- No `any` — use generics or proper union types
-
-### Module pattern
-- ES modules only (`"type": "module"` in package.json)
-- All source files are `.ts`, exported directly (no build step)
+| Skill | When to use |
+|-------|-------------|
+| `/new-adapter` | Add a new IDB interface adapter (e.g. `IDBOpenDBRequest`) |
+| `/check` | Full quality gate: tests + lint before committing |
+| `/pr-update` | Push changes and update PR description |
 
 ## Project Structure
 
 ```
 indexeddb/
-├── abort.ts          # AbortError signal utility
-├── adoptRequest.ts   # IDBRequest → Promise adapter (AdoptRequest class)
-├── cursor.ts         # Promise-based IDBCursor wrapper (Cursor class)
-├── IDBIndex.ts       # Promise-based IDBIndex adapter (IndexAdapter class)
-├── on.ts             # AsyncIterableIterator for continuous events (On class)
-├── once.ts           # Single-event async listener (Once class)
-├── types.ts          # Runtime type definitions
-├── types.d.ts        # Type declarations
-├── index.ts          # Main entry — re-exports everything
-├── index.d.ts        # Public TypeScript declarations
-└── tests/            # Node test runner tests (tsx)
+├── abort.ts            # getAbortReason() — shared AbortError factory
+├── adoptRequest.ts     # AdoptRequest<T> — IDBRequest → Promise
+├── cursor.ts           # Cursor — promise-based IDBCursor wrapper
+├── IDBIndex.ts         # IndexAdapter — wraps IDBIndex
+├── IDBObjectStore.ts   # ObjectStoreAdapter — wraps IDBObjectStore
+├── IDBTransaction.ts   # TransactionAdapter — wraps IDBTransaction
+├── IDBDatabase.ts      # DatabaseAdapter — wraps IDBDatabase
+├── on.ts               # On<T> — AsyncIterableIterator over EventTarget
+├── once.ts             # Once<T> — single-event Promise from EventTarget
+├── types.ts / types.d.ts  # Shared types: OnOptions, IDBTarget, IDBEventMap
+├── index.ts            # Re-exports all public classes + types
+├── index.d.ts          # Public TypeScript declarations
+└── tests/
     ├── adoptRequest.test.ts
-    ├── cursor.test.ts    # Largest (~400 lines), mock IndexedDB classes
+    ├── cursor.test.ts          # ~400 lines, largest test file
     ├── IDBIndex.test.ts
+    ├── IDBObjectStore.test.ts  # 17 tests
+    ├── IDBTransaction.test.ts  # 5 tests
+    ├── IDBDatabase.test.ts     # 7 tests
     ├── on.test.ts
     └── once.test.ts
 ```
 
-## Testing Notes
+## Adapter Dependency Chain (no circular deps)
 
-- Uses `node:test` and `assert/strict` — no external test library
-- Mock classes (MockCursor, MockObjectStore, etc.) defined inside test files
-- Run with `tsx --test` (transpiles TS on the fly)
-- Test files in `tests/` directory, pattern: `*.test.ts`
+```
+DatabaseAdapter
+  └─ IDBDatabase.createObjectStore() → ObjectStoreAdapter
+  └─ IDBDatabase.transaction()       → TransactionAdapter
+       └─ IDBTransaction.objectStore() → ObjectStoreAdapter
+            └─ IDBObjectStore.createIndex() → IndexAdapter
+            └─ IDBObjectStore.index()       → IndexAdapter
+                 └─ IDBIndex.openCursor()   → AsyncGenerator<Cursor>
+                      └─ Cursor ← AdoptRequest
+```
+
+Cross-references that stay as raw DOM types to avoid cycles:
+- `ObjectStoreAdapter.transaction` → `IDBTransaction` (not `TransactionAdapter`)
+- `TransactionAdapter.db` → `IDBDatabase` (not `DatabaseAdapter`)
+- `IndexAdapter.objectStore` → `IDBObjectStore` (not `ObjectStoreAdapter`)
+
+## Code Conventions
+
+### Prettier (enforced, `.prettierrc.json`)
+- Single quotes, semicolons, trailing commas: all
+- Print width: 100 chars, tab width: 2 spaces
+
+### ESLint rules (`.eslintrc.cjs`)
+- **No default exports** — named exports only
+- Max 1 class per file (class expressions allowed)
+- Import extensions disabled for `.ts`/`.js`
+- `no-use-before-define` allows function declarations
+- Test files: relaxed rules (dupe class members, unused vars allowed)
+
+### TypeScript (`tsconfig.json`)
+- `"strict": true`, `"noEmit": true`, `"moduleResolution": "Bundler"`
+- No `any` — use generics or union types
+- DOM + ES2022 libs
+
+### Module pattern
+- ES modules only (`"type": "module"`)
+- `.ts` source exported directly — no build step
+
+## Writing a New Adapter (pattern reference)
+
+```typescript
+// 1. Import base primitives
+import { AdoptRequest } from './adoptRequest';
+import { Cursor } from './cursor';           // only if cursor methods exist
+import { SomeOtherAdapter } from './IDB...'; // only if needed, avoid cycles
+
+export class XyzAdapter {
+  // 2. Store raw DOM object
+  constructor(private readonly xyz: IDBXyz) {}
+
+  // 3. Pass-through readonly properties
+  get name(): string { return this.xyz.name; }
+
+  // 4. Promisify IDBRequest methods
+  get(key: IDBValidKey): Promise<unknown> {
+    return new AdoptRequest(this.xyz.get(key)).toPromise();
+  }
+
+  // 5. AsyncGenerator for cursor methods (copy pattern from IDBIndex.ts)
+  async *openCursor(): AsyncGenerator<Cursor, void, undefined> {
+    const firstRequest = this.xyz.openCursor() as unknown as IDBRequest<IDBCursorWithValue | null>;
+    let cursor = await new AdoptRequest<IDBCursorWithValue | null>(firstRequest).toPromise();
+    while (cursor) {
+      yield new Cursor(cursor);
+      const nextRequest = cursor.continue() as unknown as IDBRequest<IDBCursorWithValue | null>;
+      // eslint-disable-next-line no-await-in-loop -- each iteration awaits next cursor
+      cursor = await new AdoptRequest<IDBCursorWithValue | null>(nextRequest).toPromise();
+    }
+  }
+
+  // 6. Static factory (required by convention)
+  static from(xyz: IDBXyz): XyzAdapter { return new XyzAdapter(xyz); }
+}
+```
+
+## Writing Tests (pattern reference)
+
+```typescript
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { XyzAdapter } from '../IDBXyz';
+
+// Helper: fake IDBRequest that fires success asynchronously
+function createRequest<T>(result: T): IDBRequest<T> {
+  const req = new EventTarget() as IDBRequest<T>;
+  (req as { result: T }).result = result;
+  (req as { error: unknown }).error = null;
+  setTimeout(() => req.dispatchEvent(new Event('success')), 0);
+  return req;
+}
+
+// Mock must implement the full DOM interface (TypeScript strict checks)
+class MockIDBXyz implements IDBXyz {
+  // implement all required properties and methods
+}
+
+test('XyzAdapter.method returns expected value', async () => {
+  const adapter = new XyzAdapter(new MockIDBXyz());
+  const result = await adapter.method(key);
+  assert.deepEqual(result, expected);
+});
+```
+
+## Commit Workflow
+
+Two layers enforce tests before every commit:
+
+1. **Git pre-commit hook** (`.git/hooks/pre-commit`) — runs `npm test`, blocks commit on failure
+2. **Claude Code PreToolUse hook** (`.claude/hooks/test-before-commit.sh`) — intercepts `git commit` Bash calls, runs `npm test`, returns `permissionDecision: "deny"` if tests fail
+
+Both are already active. Just run `git commit` normally — hooks handle the rest.
 
 ## Important Constraints
 
 - **No build step** — library exports `.ts` source directly
-- **No runtime deps** — everything is pure TS/JS using native APIs
-- **Browser API target** — code uses DOM types (IDBRequest, IDBCursor, etc.)
+- **No runtime deps** — pure TS/JS using native browser APIs
+- **Browser API target** — DOM types (IDBRequest, IDBCursor, etc.)
 - **Private package** — not published to npm
+- **Strict TypeScript** — mock classes in tests must implement full DOM interfaces

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,84 @@
+# IndexedDB Fork — Claude Code Guide
+
+## Project Overview
+
+TypeScript library providing promise-based and async iterator utilities for the IndexedDB API. Private package, no external runtime dependencies.
+
+## Tech Stack
+
+- **Language:** TypeScript 5.7 (strict mode, ES2022 target, ESNext modules)
+- **Runtime:** Browser (DOM lib) + Node.js types
+- **Test runner:** Node.js built-in `node:test` via `tsx`
+- **Linter:** ESLint 8 (airbnb-base + airbnb-typescript/base + prettier)
+- **Formatter:** Prettier 3
+- **Package manager:** npm (v3 lockfile)
+
+## Key Commands
+
+```bash
+npm test          # Run all tests via tsx --test
+npm run lint      # Check linting
+npm run lint:fix  # Auto-fix linting issues
+npm run format    # Format with Prettier
+```
+
+## Code Conventions
+
+### Prettier (enforced)
+- Single quotes (`'`)
+- Semicolons: yes
+- Trailing commas: all
+- Print width: 100 chars
+- Tab width: 2 spaces
+
+### ESLint rules
+- **No default exports** — use named exports only
+- Max 1 class per file (class expressions allowed)
+- Import extensions disabled for `.ts`/`.js` files
+- `no-use-before-define` allows function declarations
+
+### TypeScript
+- Strict mode (`"strict": true`)
+- `noEmit: true` — no compiled output, types only
+- `moduleResolution: "Bundler"`
+- No `any` — use generics or proper union types
+
+### Module pattern
+- ES modules only (`"type": "module"` in package.json)
+- All source files are `.ts`, exported directly (no build step)
+
+## Project Structure
+
+```
+indexeddb/
+├── abort.ts          # AbortError signal utility
+├── adoptRequest.ts   # IDBRequest → Promise adapter (AdoptRequest class)
+├── cursor.ts         # Promise-based IDBCursor wrapper (Cursor class)
+├── IDBIndex.ts       # Promise-based IDBIndex adapter (IndexAdapter class)
+├── on.ts             # AsyncIterableIterator for continuous events (On class)
+├── once.ts           # Single-event async listener (Once class)
+├── types.ts          # Runtime type definitions
+├── types.d.ts        # Type declarations
+├── index.ts          # Main entry — re-exports everything
+├── index.d.ts        # Public TypeScript declarations
+└── tests/            # Node test runner tests (tsx)
+    ├── adoptRequest.test.ts
+    ├── cursor.test.ts    # Largest (~400 lines), mock IndexedDB classes
+    ├── IDBIndex.test.ts
+    ├── on.test.ts
+    └── once.test.ts
+```
+
+## Testing Notes
+
+- Uses `node:test` and `assert/strict` — no external test library
+- Mock classes (MockCursor, MockObjectStore, etc.) defined inside test files
+- Run with `tsx --test` (transpiles TS on the fly)
+- Test files in `tests/` directory, pattern: `*.test.ts`
+
+## Important Constraints
+
+- **No build step** — library exports `.ts` source directly
+- **No runtime deps** — everything is pure TS/JS using native APIs
+- **Browser API target** — code uses DOM types (IDBRequest, IDBCursor, etc.)
+- **Private package** — not published to npm

--- a/IDBDatabase.ts
+++ b/IDBDatabase.ts
@@ -1,0 +1,42 @@
+import { ObjectStoreAdapter } from './IDBObjectStore';
+import { TransactionAdapter } from './IDBTransaction';
+
+export class DatabaseAdapter {
+  constructor(private readonly db: IDBDatabase) {}
+
+  get name(): string {
+    return this.db.name;
+  }
+
+  get version(): number {
+    return this.db.version;
+  }
+
+  get objectStoreNames(): string[] {
+    return Array.from(this.db.objectStoreNames);
+  }
+
+  close(): void {
+    this.db.close();
+  }
+
+  deleteObjectStore(name: string): void {
+    this.db.deleteObjectStore(name);
+  }
+
+  createObjectStore(name: string, options?: IDBObjectStoreParameters): ObjectStoreAdapter {
+    return new ObjectStoreAdapter(this.db.createObjectStore(name, options));
+  }
+
+  transaction(
+    storeNames: string | string[],
+    mode?: IDBTransactionMode,
+    options?: IDBTransactionOptions,
+  ): TransactionAdapter {
+    return new TransactionAdapter(this.db.transaction(storeNames, mode, options));
+  }
+
+  static from(db: IDBDatabase): DatabaseAdapter {
+    return new DatabaseAdapter(db);
+  }
+}

--- a/IDBIndex.ts
+++ b/IDBIndex.ts
@@ -1,0 +1,102 @@
+import { AdoptRequest } from './adoptRequest';
+import { Cursor } from './cursor';
+
+
+export class IndexAdapter {
+  constructor(private readonly index: IDBIndex) {}
+
+  get name(): string {
+    return this.index.name;
+  }
+
+  get objectStore(): IDBObjectStore {
+    return this.index.objectStore;
+  }
+
+  get keyPath(): string | string[] {
+    return this.index.keyPath;
+  }
+
+  get multiEntry(): boolean {
+    return this.index.multiEntry;
+  }
+
+  get unique(): boolean {
+    return this.index.unique;
+  }
+
+ 
+  get(key: IDBValidKey | IDBKeyRange): Promise<unknown> {
+    return new AdoptRequest(this.index.get(key)).toPromise();
+  }
+
+ 
+  getAll(query?: IDBValidKey | IDBKeyRange, count?: number): Promise<unknown[]> {
+    return new AdoptRequest(this.index.getAll(query, count)).toPromise();
+  }
+
+
+  getAllKeys(
+    query?: IDBValidKey | IDBKeyRange,
+    count?: number,
+  ): Promise<IDBValidKey[]> {
+    return new AdoptRequest(this.index.getAllKeys(query, count)).toPromise();
+  }
+
+  getKey(query?: IDBValidKey | IDBKeyRange): Promise<IDBValidKey | undefined> {
+    return new AdoptRequest(
+      this.index.getKey(query as IDBValidKey | IDBKeyRange),
+    ).toPromise();
+  }
+
+  count(query?: IDBValidKey | IDBKeyRange): Promise<number> {
+    return new AdoptRequest(this.index.count(query)).toPromise();
+  }
+
+  
+  async *openCursor(
+    range?: IDBValidKey | IDBKeyRange,
+    direction?: IDBCursorDirection,
+  ): AsyncGenerator<Cursor, void, undefined> {
+    const firstRequest = this.index.openCursor(range, direction) as unknown as IDBRequest<IDBCursorWithValue | null>;
+    let cursor: IDBCursorWithValue | null = await new AdoptRequest<
+      IDBCursorWithValue | null
+    >(firstRequest).toPromise();
+
+    while (cursor) {
+      yield new Cursor(cursor);
+      const nextRequest = cursor.continue() as unknown as IDBRequest<
+        IDBCursorWithValue | null
+      >;
+      // eslint-disable-next-line no-await-in-loop -- each iteration awaits next cursor
+      cursor = await new AdoptRequest<IDBCursorWithValue | null>(
+        nextRequest,
+      ).toPromise();
+    }
+  }
+
+ 
+  async *openKeyCursor(
+    range?: IDBValidKey | IDBKeyRange,
+    direction?: IDBCursorDirection,
+  ): AsyncGenerator<Cursor, void, undefined> {
+    const firstRequest = this.index.openKeyCursor(range, direction) as unknown as IDBRequest<IDBCursor | null>;
+    let cursor: IDBCursor | null = await new AdoptRequest<IDBCursor | null>(
+      firstRequest,
+    ).toPromise();
+
+    while (cursor) {
+      yield new Cursor(cursor);
+      const nextRequest = cursor.continue() as unknown as IDBRequest<
+        IDBCursor | null
+      >;
+      // eslint-disable-next-line no-await-in-loop -- each iteration awaits next cursor
+      cursor = await new AdoptRequest<IDBCursor | null>(nextRequest).toPromise();
+    }
+  }
+
+ 
+  static from(index: IDBIndex): IndexAdapter {
+    return new IndexAdapter(index);
+  }
+}

--- a/IDBObjectStore.ts
+++ b/IDBObjectStore.ts
@@ -9,7 +9,7 @@ export class ObjectStoreAdapter {
     return this.store.name;
   }
 
-  get keyPath(): string | string[] {
+  get keyPath(): string | string[] | null {
     return this.store.keyPath;
   }
 

--- a/IDBObjectStore.ts
+++ b/IDBObjectStore.ts
@@ -1,0 +1,119 @@
+import { AdoptRequest } from './adoptRequest';
+import { Cursor } from './cursor';
+import { IndexAdapter } from './IDBIndex';
+
+export class ObjectStoreAdapter {
+  constructor(private readonly store: IDBObjectStore) {}
+
+  get name(): string {
+    return this.store.name;
+  }
+
+  get keyPath(): string | string[] {
+    return this.store.keyPath;
+  }
+
+  get indexNames(): string[] {
+    return Array.from(this.store.indexNames);
+  }
+
+  get autoIncrement(): boolean {
+    return this.store.autoIncrement;
+  }
+
+  get transaction(): IDBTransaction {
+    return this.store.transaction;
+  }
+
+  add(value: unknown, key?: IDBValidKey): Promise<IDBValidKey> {
+    return new AdoptRequest<IDBValidKey>(this.store.add(value, key)).toPromise();
+  }
+
+  clear(): Promise<undefined> {
+    return new AdoptRequest<undefined>(this.store.clear()).toPromise();
+  }
+
+  count(query?: IDBValidKey | IDBKeyRange): Promise<number> {
+    return new AdoptRequest<number>(this.store.count(query)).toPromise();
+  }
+
+  delete(query: IDBValidKey | IDBKeyRange): Promise<undefined> {
+    return new AdoptRequest<undefined>(this.store.delete(query)).toPromise();
+  }
+
+  get(query: IDBValidKey | IDBKeyRange): Promise<unknown> {
+    return new AdoptRequest(this.store.get(query)).toPromise();
+  }
+
+  getAll(query?: IDBValidKey | IDBKeyRange | null, count?: number): Promise<unknown[]> {
+    return new AdoptRequest(this.store.getAll(query, count)).toPromise();
+  }
+
+  getAllKeys(query?: IDBValidKey | IDBKeyRange | null, count?: number): Promise<IDBValidKey[]> {
+    return new AdoptRequest(this.store.getAllKeys(query, count)).toPromise();
+  }
+
+  getKey(query: IDBValidKey | IDBKeyRange): Promise<IDBValidKey | undefined> {
+    return new AdoptRequest(this.store.getKey(query)).toPromise();
+  }
+
+  put(value: unknown, key?: IDBValidKey): Promise<IDBValidKey> {
+    return new AdoptRequest<IDBValidKey>(this.store.put(value, key)).toPromise();
+  }
+
+  createIndex(name: string, keyPath: string | string[], options?: IDBIndexParameters): IndexAdapter {
+    return new IndexAdapter(this.store.createIndex(name, keyPath, options));
+  }
+
+  deleteIndex(name: string): void {
+    this.store.deleteIndex(name);
+  }
+
+  index(name: string): IndexAdapter {
+    return new IndexAdapter(this.store.index(name));
+  }
+
+  async *openCursor(
+    query?: IDBValidKey | IDBKeyRange | null,
+    direction?: IDBCursorDirection,
+  ): AsyncGenerator<Cursor, void, undefined> {
+    const firstRequest = this.store.openCursor(
+      query,
+      direction,
+    ) as unknown as IDBRequest<IDBCursorWithValue | null>;
+    let cursor: IDBCursorWithValue | null = await new AdoptRequest<IDBCursorWithValue | null>(
+      firstRequest,
+    ).toPromise();
+
+    while (cursor) {
+      yield new Cursor(cursor);
+      const nextRequest = cursor.continue() as unknown as IDBRequest<IDBCursorWithValue | null>;
+      // eslint-disable-next-line no-await-in-loop -- each iteration awaits next cursor
+      cursor = await new AdoptRequest<IDBCursorWithValue | null>(nextRequest).toPromise();
+    }
+  }
+
+  async *openKeyCursor(
+    query?: IDBValidKey | IDBKeyRange | null,
+    direction?: IDBCursorDirection,
+  ): AsyncGenerator<Cursor, void, undefined> {
+    const firstRequest = this.store.openKeyCursor(
+      query,
+      direction,
+    ) as unknown as IDBRequest<IDBCursor | null>;
+    let cursor: IDBCursor | null = await new AdoptRequest<IDBCursor | null>(
+      firstRequest,
+    ).toPromise();
+
+    while (cursor) {
+      yield new Cursor(cursor);
+      const nextRequest = cursor.continue() as unknown as IDBRequest<IDBCursor | null>;
+      // eslint-disable-next-line no-await-in-loop -- each iteration awaits next cursor
+      cursor = await new AdoptRequest<IDBCursor | null>(nextRequest).toPromise();
+    }
+  }
+
+  static from(store: IDBObjectStore): ObjectStoreAdapter {
+    return new ObjectStoreAdapter(store);
+  }
+}

--- a/IDBTransaction.ts
+++ b/IDBTransaction.ts
@@ -1,0 +1,41 @@
+import { ObjectStoreAdapter } from './IDBObjectStore';
+
+export class TransactionAdapter {
+  constructor(private readonly transaction: IDBTransaction) {}
+
+  get db(): IDBDatabase {
+    return this.transaction.db;
+  }
+
+  get durability(): IDBTransactionDurability {
+    return this.transaction.durability;
+  }
+
+  get error(): DOMException | null {
+    return this.transaction.error;
+  }
+
+  get mode(): IDBTransactionMode {
+    return this.transaction.mode;
+  }
+
+  get objectStoreNames(): string[] {
+    return Array.from(this.transaction.objectStoreNames);
+  }
+
+  objectStore(name: string): ObjectStoreAdapter {
+    return new ObjectStoreAdapter(this.transaction.objectStore(name));
+  }
+
+  commit(): void {
+    this.transaction.commit();
+  }
+
+  abort(): void {
+    this.transaction.abort();
+  }
+
+  static from(transaction: IDBTransaction): TransactionAdapter {
+    return new TransactionAdapter(transaction);
+  }
+}

--- a/abort.ts
+++ b/abort.ts
@@ -1,0 +1,13 @@
+export function getAbortReason(signal?: AbortSignal) {
+  if (!signal) {
+    const error = new Error('The operation was aborted');
+    (error as { name: string }).name = 'AbortError';
+    return error;
+  }
+  if (signal.reason !== undefined) {
+    return signal.reason;
+  }
+  const error = new Error('The operation was aborted');
+  (error as { name: string }).name = 'AbortError';
+  return error;
+}

--- a/adoptRequest.ts
+++ b/adoptRequest.ts
@@ -1,0 +1,21 @@
+export function adoptRequest<T>(request: IDBRequest<T>): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    function cleanup() {
+      request.removeEventListener('success', handleSuccess);
+      request.removeEventListener('error', handleError);
+    }
+
+    function handleSuccess() {
+      cleanup();
+      resolve(request.result as T);
+    }
+
+    function handleError() {
+      cleanup();
+      reject(request.error);
+    }
+
+    request.addEventListener('success', handleSuccess, { once: true });
+    request.addEventListener('error', handleError, { once: true });
+  });
+}

--- a/cursor.ts
+++ b/cursor.ts
@@ -1,0 +1,70 @@
+import { AdoptRequest } from './adoptRequest';
+
+export class Cursor {
+  constructor(private readonly cursor: IDBCursor | IDBCursorWithValue) {}
+
+  get source(): IDBObjectStore | IDBIndex {
+    return this.cursor.source;
+  }
+
+  get direction(): IDBCursorDirection {
+    return this.cursor.direction;
+  }
+
+  get key(): IDBValidKey | undefined {
+    return this.cursor.key;
+  }
+
+  get primaryKey(): IDBValidKey | undefined {
+    return this.cursor.primaryKey;
+  }
+
+  get request(): IDBRequest<IDBCursor | IDBCursorWithValue | null> {
+    return this.cursor.request;
+  }
+
+  advance(count: number): Promise<IDBCursor | IDBCursorWithValue | null> {
+    const request = this.cursor.advance(count) as unknown as IDBRequest<
+      IDBCursor | IDBCursorWithValue | null
+    >;
+    return new AdoptRequest<IDBCursor | IDBCursorWithValue | null>(request).toPromise();
+  }
+
+  continue(key?: IDBValidKey): Promise<IDBCursor | IDBCursorWithValue | null> {
+    const request = this.cursor.continue(key) as unknown as IDBRequest<
+      IDBCursor | IDBCursorWithValue | null
+    >;
+    return new AdoptRequest<IDBCursor | IDBCursorWithValue | null>(request).toPromise();
+  }
+
+  continuePrimaryKey(
+    key: IDBValidKey,
+    primaryKey: IDBValidKey,
+  ): Promise<IDBCursor | IDBCursorWithValue | null> {
+    const request = this.cursor.continuePrimaryKey(key, primaryKey) as unknown as IDBRequest<
+      IDBCursor | IDBCursorWithValue | null
+    >;
+    return new AdoptRequest<IDBCursor | IDBCursorWithValue | null>(request).toPromise();
+  }
+
+  delete(): Promise<IDBValidKey> {
+    const request = this.cursor.delete() as unknown as IDBRequest<IDBValidKey>;
+    return new AdoptRequest<IDBValidKey>(request).toPromise();
+  }
+
+  update(value: unknown): Promise<IDBValidKey> {
+    const request = this.cursor.update(value) as unknown as IDBRequest<IDBValidKey>;
+    return new AdoptRequest<IDBValidKey>(request).toPromise();
+  }
+
+  get value(): unknown {
+    if ('value' in this.cursor) {
+      return (this.cursor as IDBCursorWithValue).value;
+    }
+    return undefined;
+  }
+
+  static from(cursor: IDBCursor | IDBCursorWithValue): Cursor {
+    return new Cursor(cursor);
+  }
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -115,7 +115,7 @@ export class ObjectStoreAdapter {
 
   readonly name: string;
 
-  readonly keyPath: string | string[];
+  readonly keyPath: string | string[] | null;
 
   readonly indexNames: string[];
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -107,3 +107,103 @@ export class Cursor {
 
   update(value: unknown): Promise<IDBValidKey>;
 }
+
+export class ObjectStoreAdapter {
+  constructor(store: IDBObjectStore);
+
+  static from(store: IDBObjectStore): ObjectStoreAdapter;
+
+  readonly name: string;
+
+  readonly keyPath: string | string[];
+
+  readonly indexNames: string[];
+
+  readonly autoIncrement: boolean;
+
+  readonly transaction: IDBTransaction;
+
+  add(value: unknown, key?: IDBValidKey): Promise<IDBValidKey>;
+
+  clear(): Promise<undefined>;
+
+  count(query?: IDBValidKey | IDBKeyRange): Promise<number>;
+
+  delete(query: IDBValidKey | IDBKeyRange): Promise<undefined>;
+
+  get(query: IDBValidKey | IDBKeyRange): Promise<unknown>;
+
+  getAll(query?: IDBValidKey | IDBKeyRange | null, count?: number): Promise<unknown[]>;
+
+  getAllKeys(query?: IDBValidKey | IDBKeyRange | null, count?: number): Promise<IDBValidKey[]>;
+
+  getKey(query: IDBValidKey | IDBKeyRange): Promise<IDBValidKey | undefined>;
+
+  put(value: unknown, key?: IDBValidKey): Promise<IDBValidKey>;
+
+  createIndex(
+    name: string,
+    keyPath: string | string[],
+    options?: IDBIndexParameters,
+  ): IndexAdapter;
+
+  deleteIndex(name: string): void;
+
+  index(name: string): IndexAdapter;
+
+  openCursor(
+    query?: IDBValidKey | IDBKeyRange | null,
+    direction?: IDBCursorDirection,
+  ): AsyncGenerator<Cursor, void, undefined>;
+
+  openKeyCursor(
+    query?: IDBValidKey | IDBKeyRange | null,
+    direction?: IDBCursorDirection,
+  ): AsyncGenerator<Cursor, void, undefined>;
+}
+
+export class TransactionAdapter {
+  constructor(transaction: IDBTransaction);
+
+  static from(transaction: IDBTransaction): TransactionAdapter;
+
+  readonly db: IDBDatabase;
+
+  readonly durability: IDBTransactionDurability;
+
+  readonly error: DOMException | null;
+
+  readonly mode: IDBTransactionMode;
+
+  readonly objectStoreNames: string[];
+
+  objectStore(name: string): ObjectStoreAdapter;
+
+  commit(): void;
+
+  abort(): void;
+}
+
+export class DatabaseAdapter {
+  constructor(db: IDBDatabase);
+
+  static from(db: IDBDatabase): DatabaseAdapter;
+
+  readonly name: string;
+
+  readonly version: number;
+
+  readonly objectStoreNames: string[];
+
+  close(): void;
+
+  deleteObjectStore(name: string): void;
+
+  createObjectStore(name: string, options?: IDBObjectStoreParameters): ObjectStoreAdapter;
+
+  transaction(
+    storeNames: string | string[],
+    mode?: IDBTransactionMode,
+    options?: IDBTransactionOptions,
+  ): TransactionAdapter;
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,28 +2,69 @@ import type { IDBEventMap, IDBTarget, OnOptions, OnceOptions } from './types';
 
 export type { IDBEventMap, IDBTarget, OnOptions, OnceOptions } from './types';
 
-export function once<T extends IDBTarget, K extends keyof IDBEventMap<T>>(
-  eventTarget: T,
-  eventName: K,
-  options?: OnceOptions,
-): Promise<IDBEventMap<T>[K]>;
+export class Once<TEvent = Event> {
+  constructor(eventTarget: EventTarget, eventName: string, options?: OnceOptions);
 
-export function once<T extends Event = Event>(
-  eventTarget: EventTarget,
-  eventName: string,
-  options?: OnceOptions,
-): Promise<T>;
+  static from<T extends IDBTarget, K extends keyof IDBEventMap<T>>(
+    eventTarget: T,
+    eventName: K,
+    options?: OnceOptions,
+  ): Once<IDBEventMap<T>[K]>;
 
-export function on<T extends IDBTarget, K extends keyof IDBEventMap<T>>(
-  eventTarget: T,
-  eventName: K,
-  options?: OnOptions,
-): AsyncIterableIterator<IDBEventMap<T>[K]>;
+  listen(): Promise<TEvent>;
+}
 
-export function on<T extends Event = Event>(
-  eventTarget: EventTarget,
-  eventName: string,
-  options?: OnOptions,
-): AsyncIterableIterator<T>;
+export class On<TEvent = Event> implements AsyncIterableIterator<TEvent> {
+  constructor(eventTarget: EventTarget, eventName: string, options?: OnOptions);
 
-export function adoptRequest<T>(request: IDBRequest<T>): Promise<T>;
+  static from<T extends IDBTarget, K extends keyof IDBEventMap<T>>(
+    eventTarget: T,
+    eventName: K,
+    options?: OnOptions,
+  ): On<IDBEventMap<T>[K]>;
+
+  [Symbol.asyncIterator](): this;
+
+  next(): Promise<IteratorResult<TEvent>>;
+
+  return(): Promise<IteratorResult<TEvent>>;
+
+  throw(reason?: unknown): Promise<IteratorResult<TEvent>>;
+}
+
+export class AdoptRequest<T> {
+  constructor(request: IDBRequest<T>);
+
+  toPromise(): Promise<T>;
+}
+
+export class Cursor {
+  constructor(cursor: IDBCursor | IDBCursorWithValue);
+
+  static from(cursor: IDBCursor | IDBCursorWithValue): Cursor;
+
+  readonly source: IDBObjectStore | IDBIndex;
+
+  readonly direction: IDBCursorDirection;
+
+  readonly key: IDBValidKey | undefined;
+
+  readonly primaryKey: IDBValidKey | undefined;
+
+  readonly request: IDBRequest<IDBCursor | IDBCursorWithValue | null>;
+
+  readonly value: unknown;
+
+  advance(count: number): Promise<IDBCursor | IDBCursorWithValue | null>;
+
+  continue(key?: IDBValidKey): Promise<IDBCursor | IDBCursorWithValue | null>;
+
+  continuePrimaryKey(
+    key: IDBValidKey,
+    primaryKey: IDBValidKey,
+  ): Promise<IDBCursor | IDBCursorWithValue | null>;
+
+  delete(): Promise<IDBValidKey>;
+
+  update(value: unknown): Promise<IDBValidKey>;
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -38,6 +38,45 @@ export class AdoptRequest<T> {
   toPromise(): Promise<T>;
 }
 
+export class IndexAdapter {
+  constructor(index: IDBIndex);
+
+  static from(index: IDBIndex): IndexAdapter;
+
+  readonly name: string;
+
+  readonly objectStore: IDBObjectStore;
+
+  readonly keyPath: string | string[];
+
+  readonly multiEntry: boolean;
+
+  readonly unique: boolean;
+
+  get(key: IDBValidKey | IDBKeyRange): Promise<unknown>;
+
+  getAll(query?: IDBValidKey | IDBKeyRange, count?: number): Promise<unknown[]>;
+
+  getAllKeys(
+    query?: IDBValidKey | IDBKeyRange,
+    count?: number,
+  ): Promise<IDBValidKey[]>;
+
+  getKey(query?: IDBValidKey | IDBKeyRange): Promise<IDBValidKey | undefined>;
+
+  count(query?: IDBValidKey | IDBKeyRange): Promise<number>;
+
+  openCursor(
+    range?: IDBValidKey | IDBKeyRange,
+    direction?: IDBCursorDirection,
+  ): AsyncGenerator<Cursor, void, undefined>;
+
+  openKeyCursor(
+    range?: IDBValidKey | IDBKeyRange,
+    direction?: IDBCursorDirection,
+  ): AsyncGenerator<Cursor, void, undefined>;
+}
+
 export class Cursor {
   constructor(cursor: IDBCursor | IDBCursorWithValue);
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,68 @@
+export type OnceOptions = {
+  signal?: AbortSignal;
+};
+
+export type OnOptions = {
+  signal?: AbortSignal;
+};
+
+export function once<K extends keyof IDBRequestEventMap>(
+  eventTarget: IDBRequest,
+  eventName: K,
+  options?: OnceOptions,
+): Promise<IDBRequestEventMap[K]>;
+
+export function once<K extends keyof IDBOpenDBRequestEventMap>(
+  eventTarget: IDBOpenDBRequest,
+  eventName: K,
+  options?: OnceOptions,
+): Promise<IDBOpenDBRequestEventMap[K]>;
+
+export function once<K extends keyof IDBTransactionEventMap>(
+  eventTarget: IDBTransaction,
+  eventName: K,
+  options?: OnceOptions,
+): Promise<IDBTransactionEventMap[K]>;
+export function once<K extends keyof IDBDatabaseEventMap>(
+  eventTarget: IDBDatabase,
+  eventName: K,
+  options?: OnceOptions,
+): Promise<IDBDatabaseEventMap[K]>;
+
+export function once<T extends Event = Event>(
+  eventTarget: EventTarget,
+  eventName: string,
+  options?: OnceOptions,
+): Promise<T>;
+
+export function on<K extends keyof IDBRequestEventMap>(
+  eventTarget: IDBRequest,
+  eventName: K,
+  options?: OnOptions,
+): AsyncIterableIterator<IDBRequestEventMap[K]>;
+
+export function on<K extends keyof IDBOpenDBRequestEventMap>(
+  eventTarget: IDBOpenDBRequest,
+  eventName: K,
+  options?: OnOptions,
+): AsyncIterableIterator<IDBOpenDBRequestEventMap[K]>;
+
+export function on<K extends keyof IDBTransactionEventMap>(
+  eventTarget: IDBTransaction,
+  eventName: K,
+  options?: OnOptions,
+): AsyncIterableIterator<IDBTransactionEventMap[K]>;
+
+export function on<K extends keyof IDBDatabaseEventMap>(
+  eventTarget: IDBDatabase,
+  eventName: K,
+  options?: OnOptions,
+): AsyncIterableIterator<IDBDatabaseEventMap[K]>;
+
+export function on<T extends Event = Event>(
+  eventTarget: EventTarget,
+  eventName: string,
+  options?: OnOptions,
+): AsyncIterableIterator<T>;
+
+export function adoptRequest<T>(request: IDBRequest<T>): Promise<T>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,33 +1,12 @@
-export type OnceOptions = {
-  signal?: AbortSignal;
-};
+import type { IDBEventMap, IDBTarget, OnOptions, OnceOptions } from './types';
 
-export type OnOptions = {
-  signal?: AbortSignal;
-};
+export type { IDBEventMap, IDBTarget, OnOptions, OnceOptions } from './types';
 
-export function once<K extends keyof IDBRequestEventMap>(
-  eventTarget: IDBRequest,
+export function once<T extends IDBTarget, K extends keyof IDBEventMap<T>>(
+  eventTarget: T,
   eventName: K,
   options?: OnceOptions,
-): Promise<IDBRequestEventMap[K]>;
-
-export function once<K extends keyof IDBOpenDBRequestEventMap>(
-  eventTarget: IDBOpenDBRequest,
-  eventName: K,
-  options?: OnceOptions,
-): Promise<IDBOpenDBRequestEventMap[K]>;
-
-export function once<K extends keyof IDBTransactionEventMap>(
-  eventTarget: IDBTransaction,
-  eventName: K,
-  options?: OnceOptions,
-): Promise<IDBTransactionEventMap[K]>;
-export function once<K extends keyof IDBDatabaseEventMap>(
-  eventTarget: IDBDatabase,
-  eventName: K,
-  options?: OnceOptions,
-): Promise<IDBDatabaseEventMap[K]>;
+): Promise<IDBEventMap<T>[K]>;
 
 export function once<T extends Event = Event>(
   eventTarget: EventTarget,
@@ -35,29 +14,11 @@ export function once<T extends Event = Event>(
   options?: OnceOptions,
 ): Promise<T>;
 
-export function on<K extends keyof IDBRequestEventMap>(
-  eventTarget: IDBRequest,
+export function on<T extends IDBTarget, K extends keyof IDBEventMap<T>>(
+  eventTarget: T,
   eventName: K,
   options?: OnOptions,
-): AsyncIterableIterator<IDBRequestEventMap[K]>;
-
-export function on<K extends keyof IDBOpenDBRequestEventMap>(
-  eventTarget: IDBOpenDBRequest,
-  eventName: K,
-  options?: OnOptions,
-): AsyncIterableIterator<IDBOpenDBRequestEventMap[K]>;
-
-export function on<K extends keyof IDBTransactionEventMap>(
-  eventTarget: IDBTransaction,
-  eventName: K,
-  options?: OnOptions,
-): AsyncIterableIterator<IDBTransactionEventMap[K]>;
-
-export function on<K extends keyof IDBDatabaseEventMap>(
-  eventTarget: IDBDatabase,
-  eventName: K,
-  options?: OnOptions,
-): AsyncIterableIterator<IDBDatabaseEventMap[K]>;
+): AsyncIterableIterator<IDBEventMap<T>[K]>;
 
 export function on<T extends Event = Event>(
   eventTarget: EventTarget,

--- a/index.ts
+++ b/index.ts
@@ -2,5 +2,6 @@ export type { IDBEventMap, IDBTarget, OnOptions, OnceOptions } from './types';
 
 export { AdoptRequest } from './adoptRequest';
 export { Cursor } from './cursor';
+export { IndexAdapter } from './IDBIndex';
 export { On } from './on';
 export { Once } from './once';

--- a/index.ts
+++ b/index.ts
@@ -1,2 +1,3 @@
-async function on<T>(eventTarget: EventTarget, eventName: string): Promise<T> {
-}
+export { adoptRequest } from './adoptRequest';
+export { on } from './on';
+export { once } from './once';

--- a/index.ts
+++ b/index.ts
@@ -1,3 +1,5 @@
+export type { IDBEventMap, IDBTarget, OnOptions, OnceOptions } from './types';
+
 export { adoptRequest } from './adoptRequest';
 export { on } from './on';
 export { once } from './once';

--- a/index.ts
+++ b/index.ts
@@ -1,5 +1,6 @@
 export type { IDBEventMap, IDBTarget, OnOptions, OnceOptions } from './types';
 
-export { adoptRequest } from './adoptRequest';
-export { on } from './on';
-export { once } from './once';
+export { AdoptRequest } from './adoptRequest';
+export { Cursor } from './cursor';
+export { On } from './on';
+export { Once } from './once';

--- a/index.ts
+++ b/index.ts
@@ -3,5 +3,8 @@ export type { IDBEventMap, IDBTarget, OnOptions, OnceOptions } from './types';
 export { AdoptRequest } from './adoptRequest';
 export { Cursor } from './cursor';
 export { IndexAdapter } from './IDBIndex';
+export { ObjectStoreAdapter } from './IDBObjectStore';
+export { TransactionAdapter } from './IDBTransaction';
+export { DatabaseAdapter } from './IDBDatabase';
 export { On } from './on';
 export { Once } from './once';

--- a/on.ts
+++ b/on.ts
@@ -1,6 +1,4 @@
-type OnOptions = {
-  signal?: AbortSignal;
-};
+import type { IDBEventMap, IDBTarget, OnOptions } from './types';
 
 const getAbortReason = (signal?: AbortSignal) => {
   if (!signal) {
@@ -16,26 +14,11 @@ const getAbortReason = (signal?: AbortSignal) => {
   return error;
 };
 
-export function on<K extends keyof IDBRequestEventMap>(
-  eventTarget: IDBRequest,
+export function on<T extends IDBTarget, K extends keyof IDBEventMap<T>>(
+  eventTarget: T,
   eventName: K,
   options?: OnOptions,
-): AsyncIterableIterator<IDBRequestEventMap[K]>;
-export function on<K extends keyof IDBOpenDBRequestEventMap>(
-  eventTarget: IDBOpenDBRequest,
-  eventName: K,
-  options?: OnOptions,
-): AsyncIterableIterator<IDBOpenDBRequestEventMap[K]>;
-export function on<K extends keyof IDBTransactionEventMap>(
-  eventTarget: IDBTransaction,
-  eventName: K,
-  options?: OnOptions,
-): AsyncIterableIterator<IDBTransactionEventMap[K]>;
-export function on<K extends keyof IDBDatabaseEventMap>(
-  eventTarget: IDBDatabase,
-  eventName: K,
-  options?: OnOptions,
-): AsyncIterableIterator<IDBDatabaseEventMap[K]>;
+): AsyncIterableIterator<IDBEventMap<T>[K]>;
 export function on<T extends Event = Event>(
   eventTarget: EventTarget,
   eventName: string,

--- a/on.ts
+++ b/on.ts
@@ -1,0 +1,157 @@
+type OnOptions = {
+  signal?: AbortSignal;
+};
+
+const getAbortReason = (signal?: AbortSignal) => {
+  if (!signal) {
+    const error = new Error('The operation was aborted');
+    (error as { name: string }).name = 'AbortError';
+    return error;
+  }
+  if (signal.reason !== undefined) {
+    return signal.reason;
+  }
+  const error = new Error('The operation was aborted');
+  (error as { name: string }).name = 'AbortError';
+  return error;
+};
+
+export function on<K extends keyof IDBRequestEventMap>(
+  eventTarget: IDBRequest,
+  eventName: K,
+  options?: OnOptions,
+): AsyncIterableIterator<IDBRequestEventMap[K]>;
+export function on<K extends keyof IDBOpenDBRequestEventMap>(
+  eventTarget: IDBOpenDBRequest,
+  eventName: K,
+  options?: OnOptions,
+): AsyncIterableIterator<IDBOpenDBRequestEventMap[K]>;
+export function on<K extends keyof IDBTransactionEventMap>(
+  eventTarget: IDBTransaction,
+  eventName: K,
+  options?: OnOptions,
+): AsyncIterableIterator<IDBTransactionEventMap[K]>;
+export function on<K extends keyof IDBDatabaseEventMap>(
+  eventTarget: IDBDatabase,
+  eventName: K,
+  options?: OnOptions,
+): AsyncIterableIterator<IDBDatabaseEventMap[K]>;
+export function on<T extends Event = Event>(
+  eventTarget: EventTarget,
+  eventName: string,
+  options?: OnOptions,
+): AsyncIterableIterator<T>;
+export function on<T extends Event = Event>(
+  eventTarget: EventTarget,
+  eventName: string,
+  options: OnOptions = {},
+): AsyncIterableIterator<T> {
+  const queue: Event[] = [];
+  const pending: Array<{
+    resolve: (value: IteratorResult<T>) => void;
+    reject: (reason?: unknown) => void;
+  }> = [];
+  let finished = false;
+  let error: unknown | null = null;
+
+  function cleanup() {
+    eventTarget.removeEventListener(eventName, handleEvent);
+    if (eventName !== 'error') {
+      eventTarget.removeEventListener('error', handleError);
+    }
+    if (options.signal) {
+      options.signal.removeEventListener('abort', handleAbort);
+    }
+  }
+
+  function handleEvent(event: Event) {
+    if (finished || error) {
+      return;
+    }
+    if (pending.length > 0) {
+      const { resolve } = pending.shift()!;
+      resolve({ value: event as T, done: false });
+      return;
+    }
+    queue.push(event);
+  }
+
+  function handleError(event: Event) {
+    if (finished || error) {
+      return;
+    }
+    error = (event as ErrorEvent).error ?? event;
+    cleanup();
+    while (pending.length > 0) {
+      const { reject } = pending.shift()!;
+      reject(error);
+    }
+  }
+
+  function handleAbort() {
+    if (finished || error) {
+      return;
+    }
+    error = getAbortReason(options.signal);
+    cleanup();
+    while (pending.length > 0) {
+      const { reject } = pending.shift()!;
+      reject(error);
+    }
+  }
+
+  eventTarget.addEventListener(eventName, handleEvent);
+  if (eventName !== 'error') {
+    eventTarget.addEventListener('error', handleError);
+  }
+  if (options.signal) {
+    if (options.signal.aborted) {
+      handleAbort();
+    } else {
+      options.signal.addEventListener('abort', handleAbort, { once: true });
+    }
+  }
+
+  return {
+    [Symbol.asyncIterator]() {
+      return this;
+    },
+    next() {
+      if (error) {
+        return Promise.reject(error);
+      }
+      if (queue.length > 0) {
+        const event = queue.shift()!;
+        return Promise.resolve({ value: event as T, done: false });
+      }
+      if (finished) {
+        return Promise.resolve({
+          value: undefined as unknown as T,
+          done: true,
+        });
+      }
+      return new Promise<IteratorResult<T>>((resolve, reject) => {
+        pending.push({ resolve, reject });
+      });
+    },
+    return() {
+      finished = true;
+      cleanup();
+      while (pending.length > 0) {
+        const { resolve } = pending.shift()!;
+        resolve({ value: undefined as unknown as T, done: true });
+      }
+      return Promise.resolve({ value: undefined as unknown as T, done: true });
+    },
+    throw(reason?: unknown) {
+      finished = true;
+      error = reason ?? new Error('Async iterator error');
+      cleanup();
+      while (pending.length > 0) {
+        const { reject } = pending.shift()!;
+        reject(error);
+      }
+      return Promise.reject(error);
+    },
+  };
+}

--- a/on.ts
+++ b/on.ts
@@ -1,18 +1,5 @@
+import { getAbortReason } from './abort';
 import type { IDBEventMap, IDBTarget, OnOptions } from './types';
-
-const getAbortReason = (signal?: AbortSignal) => {
-  if (!signal) {
-    const error = new Error('The operation was aborted');
-    (error as { name: string }).name = 'AbortError';
-    return error;
-  }
-  if (signal.reason !== undefined) {
-    return signal.reason;
-  }
-  const error = new Error('The operation was aborted');
-  (error as { name: string }).name = 'AbortError';
-  return error;
-};
 
 export function on<T extends IDBTarget, K extends keyof IDBEventMap<T>>(
   eventTarget: T,

--- a/once.ts
+++ b/once.ts
@@ -1,0 +1,92 @@
+type OnceOptions = {
+  signal?: AbortSignal;
+};
+
+const getAbortReason = (signal?: AbortSignal) => {
+  if (!signal) {
+    const error = new Error('The operation was aborted');
+    (error as { name: string }).name = 'AbortError';
+    return error;
+  }
+  if (signal.reason !== undefined) {
+    return signal.reason;
+  }
+  const error = new Error('The operation was aborted');
+  (error as { name: string }).name = 'AbortError';
+  return error;
+};
+
+export function once<K extends keyof IDBRequestEventMap>(
+  eventTarget: IDBRequest,
+  eventName: K,
+  options?: OnceOptions,
+): Promise<IDBRequestEventMap[K]>;
+
+export function once<K extends keyof IDBOpenDBRequestEventMap>(
+  eventTarget: IDBOpenDBRequest,
+  eventName: K,
+  options?: OnceOptions,
+): Promise<IDBOpenDBRequestEventMap[K]>;
+
+export function once<K extends keyof IDBTransactionEventMap>(
+  eventTarget: IDBTransaction,
+  eventName: K,
+  options?: OnceOptions,
+): Promise<IDBTransactionEventMap[K]>;
+
+export function once<K extends keyof IDBDatabaseEventMap>(
+  eventTarget: IDBDatabase,
+  eventName: K,
+  options?: OnceOptions,
+): Promise<IDBDatabaseEventMap[K]>;
+
+export function once<T extends Event = Event>(
+  eventTarget: EventTarget,
+  eventName: string,
+  options?: OnceOptions,
+): Promise<T>;
+
+export function once<T extends Event = Event>(
+  eventTarget: EventTarget,
+  eventName: string,
+  options: OnceOptions = {},
+): Promise<T> {
+  if (options.signal?.aborted) {
+    return Promise.reject(getAbortReason(options.signal));
+  }
+  return new Promise<T>((resolve, reject) => {
+    function cleanup() {
+      eventTarget.removeEventListener(eventName, handleEvent);
+      if (eventName !== 'error') {
+        eventTarget.removeEventListener('error', handleError);
+      }
+      if (options.signal) {
+        options.signal.removeEventListener('abort', handleAbort);
+      }
+    }
+
+    function handleEvent(event: Event) {
+      cleanup();
+      resolve(event as T);
+    }
+
+    function handleError(event: Event) {
+      cleanup();
+      const error = (event as ErrorEvent).error ?? event;
+      reject(error);
+    }
+
+    function handleAbort() {
+      cleanup();
+      reject(getAbortReason(options.signal));
+    }
+
+    eventTarget.addEventListener(eventName, handleEvent);
+    if (eventName !== 'error') {
+      eventTarget.addEventListener('error', handleError);
+    }
+    if (options.signal) {
+      options.signal.addEventListener('abort', handleAbort, { once: true });
+    }
+  });
+}

--- a/once.ts
+++ b/once.ts
@@ -1,59 +1,74 @@
 import { getAbortReason } from './abort';
 import type { IDBEventMap, IDBTarget, OnceOptions } from './types';
 
-export function once<T extends IDBTarget, K extends keyof IDBEventMap<T>>(
-  eventTarget: T,
-  eventName: K,
-  options?: OnceOptions,
-): Promise<IDBEventMap<T>[K]>;
+export class Once<TEvent = Event> {
+  private readonly eventTarget: EventTarget;
 
-export function once<T extends Event = Event>(
-  eventTarget: EventTarget,
-  eventName: string,
-  options?: OnceOptions,
-): Promise<T>;
+  private readonly eventName: string;
 
-export function once<T extends Event = Event>(
-  eventTarget: EventTarget,
-  eventName: string,
-  options: OnceOptions = {},
-): Promise<T> {
-  if (options.signal?.aborted) {
-    return Promise.reject(getAbortReason(options.signal));
+  private readonly options: OnceOptions;
+
+  constructor(eventTarget: EventTarget, eventName: string, options: OnceOptions = {}) {
+    this.eventTarget = eventTarget;
+    this.eventName = eventName;
+    this.options = options;
   }
-  return new Promise<T>((resolve, reject) => {
-    function cleanup() {
-      eventTarget.removeEventListener(eventName, handleEvent);
+
+  static from<T extends IDBTarget, K extends keyof IDBEventMap<T>>(
+    eventTarget: T,
+    eventName: K,
+    options?: OnceOptions,
+  ): Once<IDBEventMap<T>[K]> {
+    return new Once(eventTarget, eventName as string, options);
+  }
+
+  listen(): Promise<TEvent> {
+    const { eventTarget, eventName, options } = this;
+    if (options.signal?.aborted) {
+      return Promise.reject(getAbortReason(options.signal));
+    }
+
+    const controller = new AbortController();
+
+    const promise = new Promise<TEvent>((resolve, reject) => {
+      const handleEvent = (event: Event) => {
+        controller.abort();
+        resolve(event as TEvent);
+      };
+
+      const handleError = (event: Event) => {
+        controller.abort();
+        const error = (event as ErrorEvent).error ?? event;
+        reject(error);
+      };
+
+      const handleAbort = () => {
+        controller.abort();
+        const error = getAbortReason(options.signal);
+        reject(error);
+      };
+
+      eventTarget.addEventListener(eventName, handleEvent, {
+        signal: controller.signal,
+      });
       if (eventName !== 'error') {
-        eventTarget.removeEventListener('error', handleError);
+        eventTarget.addEventListener('error', handleError, {
+          signal: controller.signal,
+        });
       }
       if (options.signal) {
-        options.signal.removeEventListener('abort', handleAbort);
+        if (options.signal.aborted) {
+          handleAbort();
+        } else {
+          options.signal.addEventListener('abort', handleAbort, {
+            once: true,
+          });
+        }
       }
-    }
+    });
 
-    function handleEvent(event: Event) {
-      cleanup();
-      resolve(event as T);
-    }
-
-    function handleError(event: Event) {
-      cleanup();
-      const error = (event as ErrorEvent).error ?? event;
-      reject(error);
-    }
-
-    function handleAbort() {
-      cleanup();
-      reject(getAbortReason(options.signal));
-    }
-
-    eventTarget.addEventListener(eventName, handleEvent);
-    if (eventName !== 'error') {
-      eventTarget.addEventListener('error', handleError);
-    }
-    if (options.signal) {
-      options.signal.addEventListener('abort', handleAbort, { once: true });
-    }
-  });
+    return promise.finally(() => {
+      controller.abort();
+    });
+  }
 }

--- a/once.ts
+++ b/once.ts
@@ -1,6 +1,4 @@
-type OnceOptions = {
-  signal?: AbortSignal;
-};
+import type { IDBEventMap, IDBTarget, OnceOptions } from './types';
 
 const getAbortReason = (signal?: AbortSignal) => {
   if (!signal) {
@@ -16,29 +14,11 @@ const getAbortReason = (signal?: AbortSignal) => {
   return error;
 };
 
-export function once<K extends keyof IDBRequestEventMap>(
-  eventTarget: IDBRequest,
+export function once<T extends IDBTarget, K extends keyof IDBEventMap<T>>(
+  eventTarget: T,
   eventName: K,
   options?: OnceOptions,
-): Promise<IDBRequestEventMap[K]>;
-
-export function once<K extends keyof IDBOpenDBRequestEventMap>(
-  eventTarget: IDBOpenDBRequest,
-  eventName: K,
-  options?: OnceOptions,
-): Promise<IDBOpenDBRequestEventMap[K]>;
-
-export function once<K extends keyof IDBTransactionEventMap>(
-  eventTarget: IDBTransaction,
-  eventName: K,
-  options?: OnceOptions,
-): Promise<IDBTransactionEventMap[K]>;
-
-export function once<K extends keyof IDBDatabaseEventMap>(
-  eventTarget: IDBDatabase,
-  eventName: K,
-  options?: OnceOptions,
-): Promise<IDBDatabaseEventMap[K]>;
+): Promise<IDBEventMap<T>[K]>;
 
 export function once<T extends Event = Event>(
   eventTarget: EventTarget,

--- a/once.ts
+++ b/once.ts
@@ -1,18 +1,5 @@
+import { getAbortReason } from './abort';
 import type { IDBEventMap, IDBTarget, OnceOptions } from './types';
-
-const getAbortReason = (signal?: AbortSignal) => {
-  if (!signal) {
-    const error = new Error('The operation was aborted');
-    (error as { name: string }).name = 'AbortError';
-    return error;
-  }
-  if (signal.reason !== undefined) {
-    return signal.reason;
-  }
-  const error = new Error('The operation was aborted');
-  (error as { name: string }).name = 'AbortError';
-  return error;
-};
 
 export function once<T extends IDBTarget, K extends keyof IDBEventMap<T>>(
   eventTarget: T,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,4833 @@
+{
+  "name": "indexeddb",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "indexeddb",
+      "devDependencies": {
+        "@typescript-eslint/eslint-plugin": "^7.18.0",
+        "@typescript-eslint/parser": "^7.18.0",
+        "eslint": "^8.57.0",
+        "eslint-config-airbnb-typescript": "^18.0.0",
+        "eslint-config-prettier": "^9.1.0",
+        "eslint-import-resolver-typescript": "^3.6.1",
+        "eslint-plugin-import": "^2.29.1",
+        "prettier": "^3.2.5",
+        "tsx": "^4.19.3",
+        "typescript": "^5.7.3"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.8.1.tgz",
+      "integrity": "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.1.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.8.1.tgz",
+      "integrity": "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.1.0.tgz",
+      "integrity": "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.2.tgz",
+      "integrity": "sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.2.tgz",
+      "integrity": "sha512-DVNI8jlPa7Ujbr1yjU2PfUSRtAUZPG9I1RwW4F4xFB1Imiu2on0ADiI/c3td+KmDtVKNbi+nffGDQMfcIMkwIA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.2.tgz",
+      "integrity": "sha512-pvz8ZZ7ot/RBphf8fv60ljmaoydPU12VuXHImtAs0XhLLw+EXBi2BLe3OYSBslR4rryHvweW5gmkKFwTiFy6KA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.2.tgz",
+      "integrity": "sha512-z8Ank4Byh4TJJOh4wpz8g2vDy75zFL0TlZlkUkEwYXuPSgX8yzep596n6mT7905kA9uHZsf/o2OJZubl2l3M7A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.2.tgz",
+      "integrity": "sha512-davCD2Zc80nzDVRwXTcQP/28fiJbcOwvdolL0sOiOsbwBa72kegmVU0Wrh1MYrbuCL98Omp5dVhQFWRKR2ZAlg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.2.tgz",
+      "integrity": "sha512-ZxtijOmlQCBWGwbVmwOF/UCzuGIbUkqB1faQRf5akQmxRJ1ujusWsb3CVfk/9iZKr2L5SMU5wPBi1UWbvL+VQA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.2.tgz",
+      "integrity": "sha512-lS/9CN+rgqQ9czogxlMcBMGd+l8Q3Nj1MFQwBZJyoEKI50XGxwuzznYdwcav6lpOGv5BqaZXqvBSiB/kJ5op+g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.2.tgz",
+      "integrity": "sha512-tAfqtNYb4YgPnJlEFu4c212HYjQWSO/w/h/lQaBK7RbwGIkBOuNKQI9tqWzx7Wtp7bTPaGC6MJvWI608P3wXYA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.2.tgz",
+      "integrity": "sha512-vWfq4GaIMP9AIe4yj1ZUW18RDhx6EPQKjwe7n8BbIecFtCQG4CfHGaHuh7fdfq+y3LIA2vGS/o9ZBGVxIDi9hw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.2.tgz",
+      "integrity": "sha512-hYxN8pr66NsCCiRFkHUAsxylNOcAQaxSSkHMMjcpx0si13t1LHFphxJZUiGwojB1a/Hd5OiPIqDdXONia6bhTw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.2.tgz",
+      "integrity": "sha512-MJt5BRRSScPDwG2hLelYhAAKh9imjHK5+NE/tvnRLbIqUWa+0E9N4WNMjmp/kXXPHZGqPLxggwVhz7QP8CTR8w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.2.tgz",
+      "integrity": "sha512-lugyF1atnAT463aO6KPshVCJK5NgRnU4yb3FUumyVz+cGvZbontBgzeGFO1nF+dPueHD367a2ZXe1NtUkAjOtg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.2.tgz",
+      "integrity": "sha512-nlP2I6ArEBewvJ2gjrrkESEZkB5mIoaTswuqNFRv/WYd+ATtUpe9Y09RnJvgvdag7he0OWgEZWhviS1OTOKixw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.2.tgz",
+      "integrity": "sha512-C92gnpey7tUQONqg1n6dKVbx3vphKtTHJaNG2Ok9lGwbZil6DrfyecMsp9CrmXGQJmZ7iiVXvvZH6Ml5hL6XdQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.2.tgz",
+      "integrity": "sha512-B5BOmojNtUyN8AXlK0QJyvjEZkWwy/FKvakkTDCziX95AowLZKR6aCDhG7LeF7uMCXEJqwa8Bejz5LTPYm8AvA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.2.tgz",
+      "integrity": "sha512-p4bm9+wsPwup5Z8f4EpfN63qNagQ47Ua2znaqGH6bqLlmJ4bx97Y9JdqxgGZ6Y8xVTixUnEkoKSHcpRlDnNr5w==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.2.tgz",
+      "integrity": "sha512-uwp2Tip5aPmH+NRUwTcfLb+W32WXjpFejTIOWZFw/v7/KnpCDKG66u4DLcurQpiYTiYwQ9B7KOeMJvLCu/OvbA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.2.tgz",
+      "integrity": "sha512-Kj6DiBlwXrPsCRDeRvGAUb/LNrBASrfqAIok+xB0LxK8CHqxZ037viF13ugfsIpePH93mX7xfJp97cyDuTZ3cw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.2.tgz",
+      "integrity": "sha512-HwGDZ0VLVBY3Y+Nw0JexZy9o/nUAWq9MlV7cahpaXKW6TOzfVno3y3/M8Ga8u8Yr7GldLOov27xiCnqRZf0tCA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.2.tgz",
+      "integrity": "sha512-DNIHH2BPQ5551A7oSHD0CKbwIA/Ox7+78/AWkbS5QoRzaqlev2uFayfSxq68EkonB+IKjiuxBFoV8ESJy8bOHA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.2.tgz",
+      "integrity": "sha512-/it7w9Nb7+0KFIzjalNJVR5bOzA9Vay+yIPLVHfIQYG/j+j9VTH84aNB8ExGKPU4AzfaEvN9/V4HV+F+vo8OEg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.2.tgz",
+      "integrity": "sha512-LRBbCmiU51IXfeXk59csuX/aSaToeG7w48nMwA6049Y4J4+VbWALAuXcs+qcD04rHDuSCSRKdmY63sruDS5qag==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.2.tgz",
+      "integrity": "sha512-kMtx1yqJHTmqaqHPAzKCAkDaKsffmXkPHThSfRwZGyuqyIeBvf08KSsYXl+abf5HDAPMJIPnbBfXvP2ZC2TfHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.2.tgz",
+      "integrity": "sha512-Yaf78O/B3Kkh+nKABUF++bvJv5Ijoy9AN1ww904rOXZFLWVc5OLOfL56W+C8F9xn5JQZa3UX6m+IktJnIb1Jjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.2.tgz",
+      "integrity": "sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.2.tgz",
+      "integrity": "sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
+      "integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.12.4",
+        "debug": "^4.3.2",
+        "espree": "^9.6.0",
+        "globals": "^13.19.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "minimatch": "^3.1.2",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz",
+      "integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@humanwhocodes/config-array": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
+      "integrity": "sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==",
+      "deprecated": "Use @eslint/config-array instead",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanwhocodes/object-schema": "^2.0.3",
+        "debug": "^4.3.1",
+        "minimatch": "^3.0.5"
+      },
+      "engines": {
+        "node": ">=10.10.0"
+      }
+    },
+    "node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@humanwhocodes/config-array/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/object-schema": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
+      "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
+      "deprecated": "Use @eslint/object-schema instead",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
+      "integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.4.3",
+        "@emnapi/runtime": "^1.4.3",
+        "@tybys/wasm-util": "^0.10.0"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nolyfill/is-core-module": {
+      "version": "1.0.39",
+      "resolved": "https://registry.npmjs.org/@nolyfill/is-core-module/-/is-core-module-1.0.39.tgz",
+      "integrity": "sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.4.0"
+      }
+    },
+    "node_modules/@rtsao/scc": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
+      "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/json5": {
+      "version": "0.0.29",
+      "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
+      "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.18.0.tgz",
+      "integrity": "sha512-94EQTWZ40mzBc42ATNIBimBEDltSJ9RQHCC8vc/PDbxi4k8dVwUAv4o98dk50M1zB+JGFxp43FP7f8+FP8R6Sw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.10.0",
+        "@typescript-eslint/scope-manager": "7.18.0",
+        "@typescript-eslint/type-utils": "7.18.0",
+        "@typescript-eslint/utils": "7.18.0",
+        "@typescript-eslint/visitor-keys": "7.18.0",
+        "graphemer": "^1.4.0",
+        "ignore": "^5.3.1",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^1.3.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^7.0.0",
+        "eslint": "^8.56.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.18.0.tgz",
+      "integrity": "sha512-4Z+L8I2OqhZV8qA132M4wNL30ypZGYOQVBfMgxDH/K5UX0PNqTu1c6za9ST5r9+tavvHiTWmBnKzpCJ/GlVFtg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "7.18.0",
+        "@typescript-eslint/types": "7.18.0",
+        "@typescript-eslint/typescript-estree": "7.18.0",
+        "@typescript-eslint/visitor-keys": "7.18.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.56.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.18.0.tgz",
+      "integrity": "sha512-jjhdIE/FPF2B7Z1uzc6i3oWKbGcHb87Qw7AWj6jmEqNOfDFbJWtjt/XfwCpvNkpGWlcJaog5vTR+VV8+w9JflA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "7.18.0",
+        "@typescript-eslint/visitor-keys": "7.18.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.18.0.tgz",
+      "integrity": "sha512-XL0FJXuCLaDuX2sYqZUUSOJ2sG5/i1AAze+axqmLnSkNEVMVYLF+cbwlB2w8D1tinFuSikHmFta+P+HOofrLeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/typescript-estree": "7.18.0",
+        "@typescript-eslint/utils": "7.18.0",
+        "debug": "^4.3.4",
+        "ts-api-utils": "^1.3.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.56.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.18.0.tgz",
+      "integrity": "sha512-iZqi+Ds1y4EDYUtlOOC+aUmxnE9xS/yCigkjA7XpTKV6nCBd3Hp/PRGGmdwnfkV2ThMyYldP1wRpm/id99spTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.18.0.tgz",
+      "integrity": "sha512-aP1v/BSPnnyhMHts8cf1qQ6Q1IFwwRvAQGRvBFkWlo3/lH29OXA3Pts+c10nxRxIBrDnoMqzhgdwVe5f2D6OzA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@typescript-eslint/types": "7.18.0",
+        "@typescript-eslint/visitor-keys": "7.18.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "minimatch": "^9.0.4",
+        "semver": "^7.6.0",
+        "ts-api-utils": "^1.3.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.18.0.tgz",
+      "integrity": "sha512-kK0/rNa2j74XuHVcoCZxdFBMF+aq/vH83CXAOHieC+2Gis4mF8jJXT5eAfyD3K0sAxtPuwxaIOIOvhwzVDt/kw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "@typescript-eslint/scope-manager": "7.18.0",
+        "@typescript-eslint/types": "7.18.0",
+        "@typescript-eslint/typescript-estree": "7.18.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.56.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.18.0.tgz",
+      "integrity": "sha512-cDF0/Gf81QpY3xYyJKDV14Zwdmid5+uuENhjH2EqFaF0ni+yAyq/LzMaIJdhNJXZI7uLzwIlA+V7oWoyn6Curg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "7.18.0",
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
+      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@unrs/resolver-binding-android-arm-eabi": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.11.1.tgz",
+      "integrity": "sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-android-arm64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.11.1.tgz",
+      "integrity": "sha512-lCxkVtb4wp1v+EoN+HjIG9cIIzPkX5OtM03pQYkG+U5O/wL53LC4QbIeazgiKqluGeVEeBlZahHalCaBvU1a2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-darwin-arm64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.11.1.tgz",
+      "integrity": "sha512-gPVA1UjRu1Y/IsB/dQEsp2V1pm44Of6+LWvbLc9SDk1c2KhhDRDBUkQCYVWe6f26uJb3fOK8saWMgtX8IrMk3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-darwin-x64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.11.1.tgz",
+      "integrity": "sha512-cFzP7rWKd3lZaCsDze07QX1SC24lO8mPty9vdP+YVa3MGdVgPmFc59317b2ioXtgCMKGiCLxJ4HQs62oz6GfRQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-freebsd-x64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.11.1.tgz",
+      "integrity": "sha512-fqtGgak3zX4DCB6PFpsH5+Kmt/8CIi4Bry4rb1ho6Av2QHTREM+47y282Uqiu3ZRF5IQioJQ5qWRV6jduA+iGw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm-gnueabihf": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.11.1.tgz",
+      "integrity": "sha512-u92mvlcYtp9MRKmP+ZvMmtPN34+/3lMHlyMj7wXJDeXxuM0Vgzz0+PPJNsro1m3IZPYChIkn944wW8TYgGKFHw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm-musleabihf": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.11.1.tgz",
+      "integrity": "sha512-cINaoY2z7LVCrfHkIcmvj7osTOtm6VVT16b5oQdS4beibX2SYBwgYLmqhBjA1t51CarSaBuX5YNsWLjsqfW5Cw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.11.1.tgz",
+      "integrity": "sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm64-musl": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.11.1.tgz",
+      "integrity": "sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-ppc64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.11.1.tgz",
+      "integrity": "sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-riscv64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.11.1.tgz",
+      "integrity": "sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-riscv64-musl": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.11.1.tgz",
+      "integrity": "sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-s390x-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.11.1.tgz",
+      "integrity": "sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-x64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.11.1.tgz",
+      "integrity": "sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-x64-musl": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.11.1.tgz",
+      "integrity": "sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-wasm32-wasi": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.11.1.tgz",
+      "integrity": "sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^0.2.11"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.11.1.tgz",
+      "integrity": "sha512-nRcz5Il4ln0kMhfL8S3hLkxI85BXs3o8EYoattsJNdsX4YUU89iOkVn7g0VHSRxFuVMdM4Q1jEpIId1Ihim/Uw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-win32-ia32-msvc": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.11.1.tgz",
+      "integrity": "sha512-DCEI6t5i1NmAZp6pFonpD5m7i6aFrpofcp4LA2i8IIq60Jyo28hamKBxNrZcyOwVOZkgsRp9O2sXWBWP8MnvIQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-win32-x64-msvc": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.11.1.tgz",
+      "integrity": "sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/acorn": {
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/array-buffer-byte-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
+      "integrity": "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "is-array-buffer": "^3.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array-includes": {
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.9.tgz",
+      "integrity": "sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.24.0",
+        "es-object-atoms": "^1.1.1",
+        "get-intrinsic": "^1.3.0",
+        "is-string": "^1.1.1",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array-union": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/array.prototype.findlastindex": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/array.prototype.findlastindex/-/array.prototype.findlastindex-1.2.6.tgz",
+      "integrity": "sha512-F/TKATkzseUExPlfvmwQKGITM3DGTK+vkAsCZoDc5daVygbJBnjEUCbgkAvVFsgfXfX4YIqZ/27G3k3tdXrTxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.9",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "es-shim-unscopables": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.flat": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.3.tgz",
+      "integrity": "sha512-rwG/ja1neyLqCuGZ5YYrznA62D4mZXg0i1cIskIUKSiqF3Cje9/wXAls9B9s1Wa2fomMsIv8czB8jZcPmxCXFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.flatmap": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.3.tgz",
+      "integrity": "sha512-Y7Wt51eKJSyi80hFrJCePGGNo5ktJCslFuboqJsbf57CCPcm5zztluPlc4/aD8sWsKvlwatezpV4U1efk8kpjg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/arraybuffer.prototype.slice": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz",
+      "integrity": "sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.1",
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "is-array-buffer": "^3.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/async-function": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
+      "integrity": "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
+      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.0",
+        "es-define-property": "^1.0.0",
+        "get-intrinsic": "^1.2.4",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/confusing-browser-globals": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.11.tgz",
+      "integrity": "sha512-JsPKdmh8ZkmnHxDk55FZ1TqVLvEQTvoByJZRN9jzI0UjxK/QgAmsphz7PGtqgPieQZ/CQcHWXCR7ATDNhGe+YA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/data-view-buffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
+      "integrity": "sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/data-view-byte-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.2.tgz",
+      "integrity": "sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/inspect-js"
+      }
+    },
+    "node_modules/data-view-byte-offset": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.1.tgz",
+      "integrity": "sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-type": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-abstract": {
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.1.tgz",
+      "integrity": "sha512-zHXBLhP+QehSSbsS9Pt23Gg964240DPd6QCf8WpkqEXxQ7fhdZzYsocOr5u7apWonsS5EjZDmTF+/slGMyasvw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.2",
+        "arraybuffer.prototype.slice": "^1.0.4",
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "data-view-buffer": "^1.0.2",
+        "data-view-byte-length": "^1.0.2",
+        "data-view-byte-offset": "^1.0.1",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "es-set-tostringtag": "^2.1.0",
+        "es-to-primitive": "^1.3.0",
+        "function.prototype.name": "^1.1.8",
+        "get-intrinsic": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "get-symbol-description": "^1.1.0",
+        "globalthis": "^1.0.4",
+        "gopd": "^1.2.0",
+        "has-property-descriptors": "^1.0.2",
+        "has-proto": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "internal-slot": "^1.1.0",
+        "is-array-buffer": "^3.0.5",
+        "is-callable": "^1.2.7",
+        "is-data-view": "^1.0.2",
+        "is-negative-zero": "^2.0.3",
+        "is-regex": "^1.2.1",
+        "is-set": "^2.0.3",
+        "is-shared-array-buffer": "^1.0.4",
+        "is-string": "^1.1.1",
+        "is-typed-array": "^1.1.15",
+        "is-weakref": "^1.1.1",
+        "math-intrinsics": "^1.1.0",
+        "object-inspect": "^1.13.4",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.7",
+        "own-keys": "^1.0.1",
+        "regexp.prototype.flags": "^1.5.4",
+        "safe-array-concat": "^1.1.3",
+        "safe-push-apply": "^1.0.0",
+        "safe-regex-test": "^1.1.0",
+        "set-proto": "^1.0.0",
+        "stop-iteration-iterator": "^1.1.0",
+        "string.prototype.trim": "^1.2.10",
+        "string.prototype.trimend": "^1.0.9",
+        "string.prototype.trimstart": "^1.0.8",
+        "typed-array-buffer": "^1.0.3",
+        "typed-array-byte-length": "^1.0.3",
+        "typed-array-byte-offset": "^1.0.4",
+        "typed-array-length": "^1.0.7",
+        "unbox-primitive": "^1.1.0",
+        "which-typed-array": "^1.1.19"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-shim-unscopables": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.1.0.tgz",
+      "integrity": "sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-to-primitive": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.0.tgz",
+      "integrity": "sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7",
+        "is-date-object": "^1.0.5",
+        "is-symbol": "^1.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.2.tgz",
+      "integrity": "sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.2",
+        "@esbuild/android-arm": "0.27.2",
+        "@esbuild/android-arm64": "0.27.2",
+        "@esbuild/android-x64": "0.27.2",
+        "@esbuild/darwin-arm64": "0.27.2",
+        "@esbuild/darwin-x64": "0.27.2",
+        "@esbuild/freebsd-arm64": "0.27.2",
+        "@esbuild/freebsd-x64": "0.27.2",
+        "@esbuild/linux-arm": "0.27.2",
+        "@esbuild/linux-arm64": "0.27.2",
+        "@esbuild/linux-ia32": "0.27.2",
+        "@esbuild/linux-loong64": "0.27.2",
+        "@esbuild/linux-mips64el": "0.27.2",
+        "@esbuild/linux-ppc64": "0.27.2",
+        "@esbuild/linux-riscv64": "0.27.2",
+        "@esbuild/linux-s390x": "0.27.2",
+        "@esbuild/linux-x64": "0.27.2",
+        "@esbuild/netbsd-arm64": "0.27.2",
+        "@esbuild/netbsd-x64": "0.27.2",
+        "@esbuild/openbsd-arm64": "0.27.2",
+        "@esbuild/openbsd-x64": "0.27.2",
+        "@esbuild/openharmony-arm64": "0.27.2",
+        "@esbuild/sunos-x64": "0.27.2",
+        "@esbuild/win32-arm64": "0.27.2",
+        "@esbuild/win32-ia32": "0.27.2",
+        "@esbuild/win32-x64": "0.27.2"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
+      "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
+      "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@eslint-community/regexpp": "^4.6.1",
+        "@eslint/eslintrc": "^2.1.4",
+        "@eslint/js": "8.57.1",
+        "@humanwhocodes/config-array": "^0.13.0",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@nodelib/fs.walk": "^1.2.8",
+        "@ungap/structured-clone": "^1.2.0",
+        "ajv": "^6.12.4",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.2",
+        "debug": "^4.3.2",
+        "doctrine": "^3.0.0",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^7.2.2",
+        "eslint-visitor-keys": "^3.4.3",
+        "espree": "^9.6.1",
+        "esquery": "^1.4.2",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^6.0.1",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "globals": "^13.19.0",
+        "graphemer": "^1.4.0",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "is-path-inside": "^3.0.3",
+        "js-yaml": "^4.1.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.4.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.2",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3",
+        "strip-ansi": "^6.0.1",
+        "text-table": "^0.2.0"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-config-airbnb-base": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-15.0.0.tgz",
+      "integrity": "sha512-xaX3z4ZZIcFLvh2oUNvcX5oEofXda7giYmuplVxoOg5A7EXJMrUyqRgR+mhDhPK8LZ4PttFOBvCYDbX3sUoUig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "confusing-browser-globals": "^1.0.10",
+        "object.assign": "^4.1.2",
+        "object.entries": "^1.1.5",
+        "semver": "^6.3.0"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      },
+      "peerDependencies": {
+        "eslint": "^7.32.0 || ^8.2.0",
+        "eslint-plugin-import": "^2.25.2"
+      }
+    },
+    "node_modules/eslint-config-airbnb-base/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/eslint-config-airbnb-typescript": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-airbnb-typescript/-/eslint-config-airbnb-typescript-18.0.0.tgz",
+      "integrity": "sha512-oc+Lxzgzsu8FQyFVa4QFaVKiitTYiiW3frB9KYW5OWdPrqFc7FzxgB20hP4cHMlr+MBzGcLl3jnCOVOydL9mIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-config-airbnb-base": "^15.0.0"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/eslint-plugin": "^7.0.0",
+        "@typescript-eslint/parser": "^7.0.0",
+        "eslint": "^8.56.0"
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.1.2.tgz",
+      "integrity": "sha512-iI1f+D2ViGn+uvv5HuHVUamg8ll4tN+JRHGc6IJi4TP9Kl976C57fzPXgseXNs8v0iA8aSJpHsTWjDb9QJamGQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint-import-resolver-node": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.9.tgz",
+      "integrity": "sha512-WFj2isz22JahUv+B788TlO3N6zL3nNJGU8CcZbPZvVEkBPaJdCV4vy5wyghty5ROFbCRnm132v8BScu5/1BQ8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^3.2.7",
+        "is-core-module": "^2.13.0",
+        "resolve": "^1.22.4"
+      }
+    },
+    "node_modules/eslint-import-resolver-node/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-import-resolver-typescript": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-3.10.1.tgz",
+      "integrity": "sha512-A1rHYb06zjMGAxdLSkN2fXPBwuSaQ0iO5M/hdyS0Ajj1VBaRp0sPD3dn1FhME3c/JluGFbwSxyCfqdSbtQLAHQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@nolyfill/is-core-module": "1.0.39",
+        "debug": "^4.4.0",
+        "get-tsconfig": "^4.10.0",
+        "is-bun-module": "^2.0.0",
+        "stable-hash": "^0.0.5",
+        "tinyglobby": "^0.2.13",
+        "unrs-resolver": "^1.6.2"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-import-resolver-typescript"
+      },
+      "peerDependencies": {
+        "eslint": "*",
+        "eslint-plugin-import": "*",
+        "eslint-plugin-import-x": "*"
+      },
+      "peerDependenciesMeta": {
+        "eslint-plugin-import": {
+          "optional": true
+        },
+        "eslint-plugin-import-x": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-module-utils": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.12.1.tgz",
+      "integrity": "sha512-L8jSWTze7K2mTg0vos/RuLRS5soomksDPoJLXIslC7c8Wmut3bx7CPpJijDcBZtxQ5lrbUdM+s0OlNbz0DCDNw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^3.2.7"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-module-utils/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-plugin-import": {
+      "version": "2.32.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.32.0.tgz",
+      "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@rtsao/scc": "^1.1.0",
+        "array-includes": "^3.1.9",
+        "array.prototype.findlastindex": "^1.2.6",
+        "array.prototype.flat": "^1.3.3",
+        "array.prototype.flatmap": "^1.3.3",
+        "debug": "^3.2.7",
+        "doctrine": "^2.1.0",
+        "eslint-import-resolver-node": "^0.3.9",
+        "eslint-module-utils": "^2.12.1",
+        "hasown": "^2.0.2",
+        "is-core-module": "^2.16.1",
+        "is-glob": "^4.0.3",
+        "minimatch": "^3.1.2",
+        "object.fromentries": "^2.0.8",
+        "object.groupby": "^1.0.3",
+        "object.values": "^1.2.1",
+        "semver": "^6.3.1",
+        "string.prototype.trimend": "^1.0.9",
+        "tsconfig-paths": "^3.15.0"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependencies": {
+        "eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/doctrine": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
+      "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/eslint/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/espree": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
+      "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.9.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^3.4.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+      "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^3.0.4"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
+      "integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.3",
+        "rimraf": "^3.0.2"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
+      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/for-each": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/function.prototype.name": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.8.tgz",
+      "integrity": "sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "functions-have-names": "^1.2.3",
+        "hasown": "^2.0.2",
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/functions-have-names": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/generator-function": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
+      "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-symbol-description": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
+      "integrity": "sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.0.tgz",
+      "integrity": "sha512-1VKTZJCwBrvbd+Wn3AOgQP/2Av+TfTCOlE4AcRJE72W1ksZXbAx8PPBR9RzgTeSPzlPMHrbANMH3LbltH73wxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/globals": {
+      "version": "13.24.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.20.2"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globalthis": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+      "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-properties": "^1.2.1",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/globby": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/graphemer": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
+      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/has-bigints": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
+      "integrity": "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-proto": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.2.0.tgz",
+      "integrity": "sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/internal-slot": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
+      "integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "hasown": "^2.0.2",
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-array-buffer": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
+      "integrity": "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-async-function": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.1.1.tgz",
+      "integrity": "sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async-function": "^1.0.0",
+        "call-bound": "^1.0.3",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-bigint": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.1.0.tgz",
+      "integrity": "sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-bigints": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-boolean-object": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
+      "integrity": "sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-bun-module": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-bun-module/-/is-bun-module-2.0.0.tgz",
+      "integrity": "sha512-gNCGbnnnnFAUGKeZ9PdbyeGYJqewpmc2aKHUEMO5nQPWU9lOmv7jcmQIv+qHD8fXW6W7qfuCwX4rY9LNRjXrkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.7.1"
+      }
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-data-view": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.2.tgz",
+      "integrity": "sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "get-intrinsic": "^1.2.6",
+        "is-typed-array": "^1.1.13"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-date-object": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
+      "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-finalizationregistry": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz",
+      "integrity": "sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-generator-function": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
+      "integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.4",
+        "generator-function": "^2.0.0",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-map": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
+      "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-negative-zero": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
+      "integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-number-object": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
+      "integrity": "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-path-inside": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-regex": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-set": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
+      "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-shared-array-buffer": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
+      "integrity": "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-string": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
+      "integrity": "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-symbol": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz",
+      "integrity": "sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-typed-array": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakmap": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
+      "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakref": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.1.1.tgz",
+      "integrity": "sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakset": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz",
+      "integrity": "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json5": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.0"
+      },
+      "bin": {
+        "json5": "lib/cli.js"
+      }
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/napi-postinstall": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.3.4.tgz",
+      "integrity": "sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "napi-postinstall": "lib/cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/napi-postinstall"
+      }
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.assign": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
+      "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0",
+        "has-symbols": "^1.1.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object.entries": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.9.tgz",
+      "integrity": "sha512-8u/hfXFRBD1O0hPUjioLhoWFHRmt6tKA4/vZPyckBr18l1KE9uHrFaFaUi8MDRTpi4uak2goyPTSNJLXX2k2Hw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.fromentries": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.8.tgz",
+      "integrity": "sha512-k6E21FzySsSK5a21KRADBd/NGneRegFO5pLHfdQLpRDETUNJueLXs3WCzyQ3tFRDYgbq3KHGXfTbi2bs8WQ6rQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object.groupby": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/object.groupby/-/object.groupby-1.0.3.tgz",
+      "integrity": "sha512-+Lhy3TQTuzXI5hevh8sBGqbmurHbbIjAi0Z4S63nthVLmLxfbj4T54a4CfZrXIrt9iP4mVAPYMo/v99taj3wjQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.values": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.2.1.tgz",
+      "integrity": "sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/own-keys": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
+      "integrity": "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-intrinsic": "^1.2.6",
+        "object-keys": "^1.1.1",
+        "safe-push-apply": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.0.tgz",
+      "integrity": "sha512-yEPsovQfpxYfgWNhCfECjG5AQaO+K3dp6XERmOepyPDVqcJm+bjyCVO3pmU+nAPe0N5dDvekfGezt/EIiRe1TA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/reflect.getprototypeof": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
+      "integrity": "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.9",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.7",
+        "get-proto": "^1.0.1",
+        "which-builtin-type": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/regexp.prototype.flags": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
+      "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-errors": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "set-function-name": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.11",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
+      "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/safe-array-concat": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
+      "integrity": "sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "get-intrinsic": "^1.2.6",
+        "has-symbols": "^1.1.0",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">=0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-push-apply": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
+      "integrity": "sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-regex-test": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-regex": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-function-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
+      "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "functions-have-names": "^1.2.3",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-proto": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/set-proto/-/set-proto-1.0.0.tgz",
+      "integrity": "sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/stable-hash": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
+      "integrity": "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stop-iteration-iterator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
+      "integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "internal-slot": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/string.prototype.trim": {
+      "version": "1.2.10",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.10.tgz",
+      "integrity": "sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "define-data-property": "^1.1.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-object-atoms": "^1.0.0",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimend": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.9.tgz",
+      "integrity": "sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimstart": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
+      "integrity": "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/ts-api-utils": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.4.3.tgz",
+      "integrity": "sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.2.0"
+      }
+    },
+    "node_modules/tsconfig-paths": {
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
+      "integrity": "sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/json5": "^0.0.29",
+        "json5": "^1.0.2",
+        "minimist": "^1.2.6",
+        "strip-bom": "^3.0.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typed-array-buffer": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+      "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/typed-array-byte-length": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.3.tgz",
+      "integrity": "sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "for-each": "^0.3.3",
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-array-byte-offset": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.4.tgz",
+      "integrity": "sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "for-each": "^0.3.3",
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.15",
+        "reflect.getprototypeof": "^1.0.9"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-array-length": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.7.tgz",
+      "integrity": "sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "is-typed-array": "^1.1.13",
+        "possible-typed-array-names": "^1.0.0",
+        "reflect.getprototypeof": "^1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/unbox-primitive": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
+      "integrity": "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-bigints": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "which-boxed-primitive": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/unrs-resolver": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.11.1.tgz",
+      "integrity": "sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "napi-postinstall": "^0.3.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unrs-resolver"
+      },
+      "optionalDependencies": {
+        "@unrs/resolver-binding-android-arm-eabi": "1.11.1",
+        "@unrs/resolver-binding-android-arm64": "1.11.1",
+        "@unrs/resolver-binding-darwin-arm64": "1.11.1",
+        "@unrs/resolver-binding-darwin-x64": "1.11.1",
+        "@unrs/resolver-binding-freebsd-x64": "1.11.1",
+        "@unrs/resolver-binding-linux-arm-gnueabihf": "1.11.1",
+        "@unrs/resolver-binding-linux-arm-musleabihf": "1.11.1",
+        "@unrs/resolver-binding-linux-arm64-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-arm64-musl": "1.11.1",
+        "@unrs/resolver-binding-linux-ppc64-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-riscv64-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-riscv64-musl": "1.11.1",
+        "@unrs/resolver-binding-linux-s390x-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-x64-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-x64-musl": "1.11.1",
+        "@unrs/resolver-binding-wasm32-wasi": "1.11.1",
+        "@unrs/resolver-binding-win32-arm64-msvc": "1.11.1",
+        "@unrs/resolver-binding-win32-ia32-msvc": "1.11.1",
+        "@unrs/resolver-binding-win32-x64-msvc": "1.11.1"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/which-boxed-primitive": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
+      "integrity": "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-bigint": "^1.1.0",
+        "is-boolean-object": "^1.2.1",
+        "is-number-object": "^1.1.1",
+        "is-string": "^1.1.1",
+        "is-symbol": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-builtin-type": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.2.1.tgz",
+      "integrity": "sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "function.prototype.name": "^1.1.6",
+        "has-tostringtag": "^1.0.2",
+        "is-async-function": "^2.0.0",
+        "is-date-object": "^1.1.0",
+        "is-finalizationregistry": "^1.1.0",
+        "is-generator-function": "^1.0.10",
+        "is-regex": "^1.2.1",
+        "is-weakref": "^1.0.2",
+        "isarray": "^2.0.5",
+        "which-boxed-primitive": "^1.1.0",
+        "which-collection": "^1.0.2",
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-collection": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
+      "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-map": "^2.0.3",
+        "is-set": "^2.0.3",
+        "is-weakmap": "^2.0.2",
+        "is-weakset": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.20",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
+      "integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "name": "indexeddb",
       "devDependencies": {
+        "@types/node": "^22.11.0",
         "@typescript-eslint/eslint-plugin": "^7.18.0",
         "@typescript-eslint/parser": "^7.18.0",
         "eslint": "^8.57.0",
@@ -728,6 +729,16 @@
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.7.tgz",
+      "integrity": "sha512-MciR4AKGHWl7xwxkBa6xUGxQJ4VBOmPTF7sL+iGzuahOFaO0jHCsuEfS80pan1ef4gWId1oWOweIhrDEYLuaOw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "7.18.0",
@@ -4648,6 +4659,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/unrs-resolver": {
       "version": "1.11.1",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "types.d.ts",
     "abort.ts",
     "adoptRequest.ts",
+    "cursor.ts",
     "on.ts",
     "once.ts"
   ],

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "abort.ts",
     "adoptRequest.ts",
     "cursor.ts",
+    "IDBIndex.ts",
     "on.ts",
     "once.ts"
   ],

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
   "files": [
     "index.ts",
     "index.d.ts",
+    "types.ts",
+    "types.d.ts",
     "adoptRequest.ts",
     "on.ts",
     "once.ts"

--- a/package.json
+++ b/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "indexeddb",
+  "private": true,
+  "type": "module",
+  "types": "./index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./index.d.ts",
+      "default": "./index.ts"
+    }
+  },
+  "files": [
+    "index.ts",
+    "index.d.ts",
+    "adoptRequest.ts",
+    "on.ts",
+    "once.ts"
+  ],
+  "scripts": {
+    "test": "tsx --test",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
+    "format": "prettier --write ."
+  },
+  "devDependencies": {
+    "@typescript-eslint/eslint-plugin": "^7.18.0",
+    "@typescript-eslint/parser": "^7.18.0",
+    "eslint": "^8.57.0",
+    "eslint-config-airbnb-typescript": "^18.0.0",
+    "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-import": "^2.29.1",
+    "eslint-import-resolver-typescript": "^3.6.1",
+    "prettier": "^3.2.5",
+    "tsx": "^4.19.3",
+    "typescript": "^5.7.3"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
     "adoptRequest.ts",
     "cursor.ts",
     "IDBIndex.ts",
+    "IDBObjectStore.ts",
+    "IDBTransaction.ts",
+    "IDBDatabase.ts",
     "on.ts",
     "once.ts"
   ],

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "index.d.ts",
     "types.ts",
     "types.d.ts",
+    "abort.ts",
     "adoptRequest.ts",
     "on.ts",
     "once.ts"

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^7.18.0",
     "@typescript-eslint/parser": "^7.18.0",
+    "@types/node": "^22.11.0",
     "eslint": "^8.57.0",
     "eslint-config-airbnb-typescript": "^18.0.0",
     "eslint-config-prettier": "^9.1.0",

--- a/tests/IDBDatabase.test.ts
+++ b/tests/IDBDatabase.test.ts
@@ -1,0 +1,230 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { DatabaseAdapter } from '../IDBDatabase';
+import { ObjectStoreAdapter } from '../IDBObjectStore';
+import { TransactionAdapter } from '../IDBTransaction';
+
+function makeDomStringList(items: string[]): DOMStringList {
+  return {
+    length: items.length,
+    item: (index: number) => items[index] ?? null,
+    contains: (str: string) => items.includes(str),
+    [Symbol.iterator]: items[Symbol.iterator].bind(items),
+  } as unknown as DOMStringList;
+}
+
+function createRequest<T>(result: T): IDBRequest<T> {
+  const req = new EventTarget() as IDBRequest<T>;
+  (req as { result: T }).result = result;
+  (req as { error: unknown }).error = null;
+  setTimeout(() => req.dispatchEvent(new Event('success')), 0);
+  return req;
+}
+
+class MockIDBObjectStore implements IDBObjectStore {
+  name: string;
+
+  keyPath: string | string[] = 'id';
+
+  indexNames = makeDomStringList([]);
+
+  autoIncrement = false;
+
+  transaction = {} as IDBTransaction;
+
+  constructor(name: string) {
+    this.name = name;
+  }
+
+  add(_value: unknown, _key?: IDBValidKey): IDBRequest<IDBValidKey> {
+    return createRequest(1 as IDBValidKey);
+  }
+
+  clear(): IDBRequest<undefined> {
+    return createRequest(undefined);
+  }
+
+  count(_query?: IDBValidKey | IDBKeyRange): IDBRequest<number> {
+    return createRequest(0);
+  }
+
+  createIndex(_name: string, _keyPath: string | string[], _options?: IDBIndexParameters): IDBIndex {
+    return {} as IDBIndex;
+  }
+
+  delete(_query: IDBValidKey | IDBKeyRange): IDBRequest<undefined> {
+    return createRequest(undefined);
+  }
+
+  deleteIndex(_name: string): void {}
+
+  get(_query: IDBValidKey | IDBKeyRange): IDBRequest<unknown> {
+    return createRequest(undefined);
+  }
+
+  getAll(_query?: IDBValidKey | IDBKeyRange | null, _count?: number): IDBRequest<unknown[]> {
+    return createRequest([]);
+  }
+
+  getAllKeys(
+    _query?: IDBValidKey | IDBKeyRange | null,
+    _count?: number,
+  ): IDBRequest<IDBValidKey[]> {
+    return createRequest([]);
+  }
+
+  getKey(_query: IDBValidKey | IDBKeyRange): IDBRequest<IDBValidKey | undefined> {
+    return createRequest(undefined);
+  }
+
+  index(_name: string): IDBIndex {
+    return {} as IDBIndex;
+  }
+
+  openCursor(
+    _query?: IDBValidKey | IDBKeyRange | null,
+    _direction?: IDBCursorDirection,
+  ): IDBRequest<IDBCursorWithValue | null> {
+    return createRequest(null);
+  }
+
+  openKeyCursor(
+    _query?: IDBValidKey | IDBKeyRange | null,
+    _direction?: IDBCursorDirection,
+  ): IDBRequest<IDBCursor | null> {
+    return createRequest(null);
+  }
+
+  put(_value: unknown, _key?: IDBValidKey): IDBRequest<IDBValidKey> {
+    return createRequest(1 as IDBValidKey);
+  }
+}
+
+class MockIDBTransaction extends EventTarget implements IDBTransaction {
+  db = {} as IDBDatabase;
+
+  durability: IDBTransactionDurability = 'default';
+
+  error: DOMException | null = null;
+
+  mode: IDBTransactionMode = 'readwrite';
+
+  objectStoreNames: DOMStringList;
+
+  onabort: ((this: IDBTransaction, ev: Event) => unknown) | null = null;
+
+  oncomplete: ((this: IDBTransaction, ev: Event) => unknown) | null = null;
+
+  onerror: ((this: IDBTransaction, ev: Event) => unknown) | null = null;
+
+  private readonly storeNames: string[];
+
+  constructor(storeNames: string[]) {
+    super();
+    this.storeNames = storeNames;
+    this.objectStoreNames = makeDomStringList(storeNames);
+  }
+
+  objectStore(name: string): IDBObjectStore {
+    return new MockIDBObjectStore(name) as unknown as IDBObjectStore;
+  }
+
+  commit(): void {}
+
+  abort(): void {}
+}
+
+class MockIDBDatabase extends EventTarget implements IDBDatabase {
+  name: string;
+
+  version: number;
+
+  objectStoreNames: DOMStringList;
+
+  onabort: ((this: IDBDatabase, ev: Event) => unknown) | null = null;
+
+  onclose: ((this: IDBDatabase, ev: Event) => unknown) | null = null;
+
+  onerror: ((this: IDBDatabase, ev: Event) => unknown) | null = null;
+
+  onversionchange: ((this: IDBDatabase, ev: IDBVersionChangeEvent) => unknown) | null = null;
+
+  private readonly stores: string[];
+
+  constructor(name: string, version: number, storeNames: string[]) {
+    super();
+    this.name = name;
+    this.version = version;
+    this.stores = storeNames;
+    this.objectStoreNames = makeDomStringList(storeNames);
+  }
+
+  close(): void {}
+
+  deleteObjectStore(_name: string): void {}
+
+  createObjectStore(name: string, _options?: IDBObjectStoreParameters): IDBObjectStore {
+    return new MockIDBObjectStore(name) as unknown as IDBObjectStore;
+  }
+
+  transaction(
+    storeNames: string | string[],
+    _mode?: IDBTransactionMode,
+    _options?: IDBTransactionOptions,
+  ): IDBTransaction {
+    const names = Array.isArray(storeNames) ? storeNames : [storeNames];
+    return new MockIDBTransaction(names) as unknown as IDBTransaction;
+  }
+}
+
+test('DatabaseAdapter.name and version', () => {
+  const db = new MockIDBDatabase('myDb', 2, ['users']);
+  const adapter = new DatabaseAdapter(db);
+  assert.equal(adapter.name, 'myDb');
+  assert.equal(adapter.version, 2);
+});
+
+test('DatabaseAdapter.objectStoreNames returns string array', () => {
+  const db = new MockIDBDatabase('test', 1, ['users', 'posts', 'comments']);
+  const adapter = new DatabaseAdapter(db);
+  assert.deepEqual(adapter.objectStoreNames, ['users', 'posts', 'comments']);
+});
+
+test('DatabaseAdapter.createObjectStore returns ObjectStoreAdapter', () => {
+  const db = new MockIDBDatabase('test', 1, []);
+  const adapter = new DatabaseAdapter(db);
+  const store = adapter.createObjectStore('newStore', { keyPath: 'id' });
+  assert.ok(store instanceof ObjectStoreAdapter);
+  assert.equal(store.name, 'newStore');
+});
+
+test('DatabaseAdapter.transaction returns TransactionAdapter', () => {
+  const db = new MockIDBDatabase('test', 1, ['users']);
+  const adapter = new DatabaseAdapter(db);
+  const tx = adapter.transaction('users', 'readwrite');
+  assert.ok(tx instanceof TransactionAdapter);
+  assert.deepEqual(tx.objectStoreNames, ['users']);
+});
+
+test('DatabaseAdapter.transaction with multiple stores', () => {
+  const db = new MockIDBDatabase('test', 1, ['a', 'b']);
+  const adapter = new DatabaseAdapter(db);
+  const tx = adapter.transaction(['a', 'b'], 'readonly');
+  assert.ok(tx instanceof TransactionAdapter);
+  assert.deepEqual(tx.objectStoreNames, ['a', 'b']);
+});
+
+test('DatabaseAdapter.from creates adapter', () => {
+  const db = new MockIDBDatabase('fromTest', 3, []);
+  const adapter = DatabaseAdapter.from(db);
+  assert.ok(adapter instanceof DatabaseAdapter);
+  assert.equal(adapter.name, 'fromTest');
+  assert.equal(adapter.version, 3);
+});
+
+test('DatabaseAdapter.close and deleteObjectStore are callable', () => {
+  const db = new MockIDBDatabase('test', 1, ['store']);
+  const adapter = new DatabaseAdapter(db);
+  assert.doesNotThrow(() => adapter.close());
+  assert.doesNotThrow(() => adapter.deleteObjectStore('store'));
+});

--- a/tests/IDBDatabase.test.ts
+++ b/tests/IDBDatabase.test.ts
@@ -59,22 +59,22 @@ class MockIDBObjectStore implements IDBObjectStore {
   deleteIndex(_name: string): void {}
 
   get(_query: IDBValidKey | IDBKeyRange): IDBRequest<unknown> {
-    return createRequest(undefined);
+    return createRequest<unknown>(undefined);
   }
 
   getAll(_query?: IDBValidKey | IDBKeyRange | null, _count?: number): IDBRequest<unknown[]> {
-    return createRequest([]);
+    return createRequest<unknown[]>([]);
   }
 
   getAllKeys(
     _query?: IDBValidKey | IDBKeyRange | null,
     _count?: number,
   ): IDBRequest<IDBValidKey[]> {
-    return createRequest([]);
+    return createRequest<IDBValidKey[]>([]);
   }
 
   getKey(_query: IDBValidKey | IDBKeyRange): IDBRequest<IDBValidKey | undefined> {
-    return createRequest(undefined);
+    return createRequest<IDBValidKey | undefined>(undefined);
   }
 
   index(_name: string): IDBIndex {
@@ -85,14 +85,14 @@ class MockIDBObjectStore implements IDBObjectStore {
     _query?: IDBValidKey | IDBKeyRange | null,
     _direction?: IDBCursorDirection,
   ): IDBRequest<IDBCursorWithValue | null> {
-    return createRequest(null);
+    return createRequest<IDBCursorWithValue | null>(null);
   }
 
   openKeyCursor(
     _query?: IDBValidKey | IDBKeyRange | null,
     _direction?: IDBCursorDirection,
   ): IDBRequest<IDBCursor | null> {
-    return createRequest(null);
+    return createRequest<IDBCursor | null>(null);
   }
 
   put(_value: unknown, _key?: IDBValidKey): IDBRequest<IDBValidKey> {

--- a/tests/IDBIndex.test.ts
+++ b/tests/IDBIndex.test.ts
@@ -22,25 +22,25 @@ class MockIDBIndex implements IDBIndex {
   unique = false;
 
   get(_key: IDBValidKey | IDBKeyRange): IDBRequest<unknown> {
-    return createRequest({ id: 1, name: 'a' });
+    return createRequest<unknown>({ id: 1, name: 'a' });
   }
 
   getAll(
     _query?: IDBValidKey | IDBKeyRange,
     _count?: number,
   ): IDBRequest<unknown[]> {
-    return createRequest([{ id: 1 }, { id: 2 }]);
+    return createRequest<unknown[]>([{ id: 1 }, { id: 2 }]);
   }
 
   getAllKeys(
     _query?: IDBValidKey | IDBKeyRange,
     _count?: number,
   ): IDBRequest<IDBValidKey[]> {
-    return createRequest([1, 2, 3]);
+    return createRequest<IDBValidKey[]>([1, 2, 3]);
   }
 
   getKey(_query?: IDBValidKey | IDBKeyRange): IDBRequest<IDBValidKey | undefined> {
-    return createRequest(1);
+    return createRequest<IDBValidKey | undefined>(1);
   }
 
   count(_query?: IDBValidKey | IDBKeyRange): IDBRequest<number> {

--- a/tests/IDBIndex.test.ts
+++ b/tests/IDBIndex.test.ts
@@ -1,0 +1,175 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { IndexAdapter } from '../IDBIndex';
+
+function createRequest<T>(result: T): IDBRequest<T> {
+  const req = new EventTarget() as IDBRequest<T>;
+  (req as { result: T }).result = result;
+  (req as { error: unknown }).error = null;
+  setTimeout(() => req.dispatchEvent(new Event('success')), 0);
+  return req;
+}
+
+class MockIDBIndex implements IDBIndex {
+  name = 'testIndex';
+
+  objectStore = {} as IDBObjectStore;
+
+  keyPath: string | string[] = 'id';
+
+  multiEntry = false;
+
+  unique = false;
+
+  get(_key: IDBValidKey | IDBKeyRange): IDBRequest<unknown> {
+    return createRequest({ id: 1, name: 'a' });
+  }
+
+  getAll(
+    _query?: IDBValidKey | IDBKeyRange,
+    _count?: number,
+  ): IDBRequest<unknown[]> {
+    return createRequest([{ id: 1 }, { id: 2 }]);
+  }
+
+  getAllKeys(
+    _query?: IDBValidKey | IDBKeyRange,
+    _count?: number,
+  ): IDBRequest<IDBValidKey[]> {
+    return createRequest([1, 2, 3]);
+  }
+
+  getKey(_query?: IDBValidKey | IDBKeyRange): IDBRequest<IDBValidKey | undefined> {
+    return createRequest(1);
+  }
+
+  count(_query?: IDBValidKey | IDBKeyRange): IDBRequest<number> {
+    return createRequest(42);
+  }
+
+  private cursorCalls = 0;
+
+  openCursor(
+    _range?: IDBValidKey | IDBKeyRange,
+    _direction?: IDBCursorDirection,
+  ): IDBRequest<IDBCursorWithValue | null> {
+    const self = this;
+    const req = new EventTarget() as IDBRequest<IDBCursorWithValue | null>;
+    const cursor: IDBCursorWithValue = {
+      source: this,
+      direction: 'next',
+      key: 1,
+      primaryKey: 1,
+      value: { id: 1 },
+      request: req,
+      advance: () => (null as unknown) as IDBRequest<IDBCursorWithValue | null>,
+      continue: () => {
+        self.cursorCalls += 1;
+        const nextReq = new EventTarget() as IDBRequest<IDBCursorWithValue | null>;
+        (nextReq as { result: IDBCursorWithValue | null }).result =
+          self.cursorCalls < 2 ? (cursor as IDBCursorWithValue) : null;
+        setTimeout(() => nextReq.dispatchEvent(new Event('success')), 0);
+        return nextReq;
+      },
+      continuePrimaryKey: () =>
+        (null as unknown) as IDBRequest<IDBCursorWithValue | null>,
+      delete: () => (null as unknown) as IDBRequest<undefined>,
+      update: () => (null as unknown) as IDBRequest<IDBValidKey>,
+    };
+    (req as { result: IDBCursorWithValue | null }).result = cursor;
+    setTimeout(() => req.dispatchEvent(new Event('success')), 0);
+    return req;
+  }
+
+  openKeyCursor(
+    _range?: IDBValidKey | IDBKeyRange,
+    _direction?: IDBCursorDirection,
+  ): IDBRequest<IDBCursor | null> {
+    const self = this;
+    const req = new EventTarget() as IDBRequest<IDBCursor | null>;
+    const cursor: IDBCursor = {
+      source: this,
+      direction: 'next',
+      key: 1,
+      primaryKey: 1,
+      request: req,
+      advance: () => (null as unknown) as IDBRequest<IDBCursor | null>,
+      continue: () => {
+        self.cursorCalls += 1;
+        const nextReq = new EventTarget() as IDBRequest<IDBCursor | null>;
+        (nextReq as { result: IDBCursor | null }).result =
+          self.cursorCalls < 2 ? cursor : null;
+        setTimeout(() => nextReq.dispatchEvent(new Event('success')), 0);
+        return nextReq;
+      },
+      continuePrimaryKey: () => (null as unknown) as IDBRequest<IDBCursor | null>,
+      delete: () => (null as unknown) as IDBRequest<undefined>,
+      update: () => (null as unknown) as IDBRequest<IDBValidKey>,
+    };
+    (req as { result: IDBCursor | null }).result = cursor;
+    setTimeout(() => req.dispatchEvent(new Event('success')), 0);
+    return req;
+  }
+}
+
+test('IndexAdapter.get returns value', async () => {
+  const index = new MockIDBIndex();
+  const adapter = new IndexAdapter(index);
+  const value = await adapter.get(1);
+  assert.deepEqual(value, { id: 1, name: 'a' });
+});
+
+test('IndexAdapter.getAll returns array', async () => {
+  const adapter = new IndexAdapter(new MockIDBIndex());
+  const arr = await adapter.getAll();
+  assert.deepEqual(arr, [{ id: 1 }, { id: 2 }]);
+});
+
+test('IndexAdapter.getAllKeys returns keys', async () => {
+  const adapter = new IndexAdapter(new MockIDBIndex());
+  const keys = await adapter.getAllKeys();
+  assert.deepEqual(keys, [1, 2, 3]);
+});
+
+test('IndexAdapter.getKey returns single key', async () => {
+  const adapter = new IndexAdapter(new MockIDBIndex());
+  const key = await adapter.getKey();
+  assert.equal(key, 1);
+});
+
+test('IndexAdapter.count returns number', async () => {
+  const adapter = new IndexAdapter(new MockIDBIndex());
+  const n = await adapter.count();
+  assert.equal(n, 42);
+});
+
+test('IndexAdapter.openCursor yields Cursor entries', async () => {
+  const index = new MockIDBIndex();
+  const adapter = new IndexAdapter(index);
+  const results: unknown[] = [];
+  /* eslint-disable no-restricted-syntax -- for-await-of is required for async iterable */
+  for await (const cursor of adapter.openCursor()) {
+    results.push(cursor.value);
+  }
+  assert.equal(results.length, 2);
+  assert.deepEqual(results[0], { id: 1 });
+  assert.deepEqual(results[1], { id: 1 });
+});
+
+test('IndexAdapter.openKeyCursor yields Cursor entries', async () => {
+  const index = new MockIDBIndex();
+  const adapter = new IndexAdapter(index);
+  const keys: IDBValidKey[] = [];
+  /* eslint-disable no-restricted-syntax -- for-await-of is required for async iterable */
+  for await (const cursor of adapter.openKeyCursor()) {
+    keys.push(cursor.key!);
+  }
+  assert.equal(keys.length, 2);
+});
+
+test('IndexAdapter.from creates adapter', () => {
+  const index = new MockIDBIndex();
+  const adapter = IndexAdapter.from(index);
+  assert.equal(adapter.name, 'testIndex');
+  assert.equal(adapter.objectStore, index.objectStore);
+});

--- a/tests/IDBObjectStore.test.ts
+++ b/tests/IDBObjectStore.test.ts
@@ -1,0 +1,281 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { ObjectStoreAdapter } from '../IDBObjectStore';
+import { IndexAdapter } from '../IDBIndex';
+import { Cursor } from '../cursor';
+
+function createRequest<T>(result: T): IDBRequest<T> {
+  const req = new EventTarget() as IDBRequest<T>;
+  (req as { result: T }).result = result;
+  (req as { error: unknown }).error = null;
+  setTimeout(() => req.dispatchEvent(new Event('success')), 0);
+  return req;
+}
+
+function makeDomStringList(items: string[]): DOMStringList {
+  return {
+    length: items.length,
+    item: (index: number) => items[index] ?? null,
+    contains: (str: string) => items.includes(str),
+    [Symbol.iterator]: items[Symbol.iterator].bind(items),
+  } as unknown as DOMStringList;
+}
+
+class MockIDBObjectStore implements IDBObjectStore {
+  name = 'testStore';
+
+  keyPath: string | string[] = 'id';
+
+  indexNames = makeDomStringList(['byName']);
+
+  autoIncrement = false;
+
+  transaction = {} as IDBTransaction;
+
+  add(_value: unknown, _key?: IDBValidKey): IDBRequest<IDBValidKey> {
+    return createRequest(1 as IDBValidKey);
+  }
+
+  clear(): IDBRequest<undefined> {
+    return createRequest(undefined);
+  }
+
+  count(_query?: IDBValidKey | IDBKeyRange): IDBRequest<number> {
+    return createRequest(3);
+  }
+
+  createIndex(name: string, keyPath: string | string[], _options?: IDBIndexParameters): IDBIndex {
+    return {
+      name,
+      keyPath,
+      objectStore: this as unknown as IDBObjectStore,
+      multiEntry: false,
+      unique: false,
+      get: createRequest,
+      getAll: createRequest,
+      getAllKeys: createRequest,
+      getKey: createRequest,
+      count: createRequest,
+      openCursor: createRequest,
+      openKeyCursor: createRequest,
+    } as unknown as IDBIndex;
+  }
+
+  delete(_query: IDBValidKey | IDBKeyRange): IDBRequest<undefined> {
+    return createRequest(undefined);
+  }
+
+  deleteIndex(_name: string): void {}
+
+  get(_query: IDBValidKey | IDBKeyRange): IDBRequest<unknown> {
+    return createRequest({ id: 1, name: 'test' });
+  }
+
+  getAll(_query?: IDBValidKey | IDBKeyRange | null, _count?: number): IDBRequest<unknown[]> {
+    return createRequest([{ id: 1 }, { id: 2 }]);
+  }
+
+  getAllKeys(
+    _query?: IDBValidKey | IDBKeyRange | null,
+    _count?: number,
+  ): IDBRequest<IDBValidKey[]> {
+    return createRequest([1, 2, 3] as IDBValidKey[]);
+  }
+
+  getKey(_query: IDBValidKey | IDBKeyRange): IDBRequest<IDBValidKey | undefined> {
+    return createRequest(1 as IDBValidKey);
+  }
+
+  index(name: string): IDBIndex {
+    return {
+      name,
+      keyPath: 'id',
+      objectStore: this as unknown as IDBObjectStore,
+      multiEntry: false,
+      unique: false,
+    } as unknown as IDBIndex;
+  }
+
+  put(_value: unknown, _key?: IDBValidKey): IDBRequest<IDBValidKey> {
+    return createRequest(42 as IDBValidKey);
+  }
+
+  private openCursorCalls = 0;
+
+  openCursor(
+    _query?: IDBValidKey | IDBKeyRange | null,
+    _direction?: IDBCursorDirection,
+  ): IDBRequest<IDBCursorWithValue | null> {
+    const self = this;
+    const req = new EventTarget() as IDBRequest<IDBCursorWithValue | null>;
+    const cursor: IDBCursorWithValue = {
+      source: this as unknown as IDBObjectStore,
+      direction: 'next',
+      key: 1,
+      primaryKey: 1,
+      value: { id: 1 },
+      request: req,
+      advance: () => null as unknown as IDBRequest<IDBCursorWithValue | null>,
+      continue: () => {
+        self.openCursorCalls += 1;
+        const nextReq = new EventTarget() as IDBRequest<IDBCursorWithValue | null>;
+        (nextReq as { result: IDBCursorWithValue | null }).result =
+          self.openCursorCalls < 2 ? cursor : null;
+        setTimeout(() => nextReq.dispatchEvent(new Event('success')), 0);
+        return nextReq;
+      },
+      continuePrimaryKey: () => null as unknown as IDBRequest<IDBCursorWithValue | null>,
+      delete: () => null as unknown as IDBRequest<undefined>,
+      update: () => null as unknown as IDBRequest<IDBValidKey>,
+    };
+    (req as { result: IDBCursorWithValue | null }).result = cursor;
+    setTimeout(() => req.dispatchEvent(new Event('success')), 0);
+    return req;
+  }
+
+  private openKeyCursorCalls = 0;
+
+  openKeyCursor(
+    _query?: IDBValidKey | IDBKeyRange | null,
+    _direction?: IDBCursorDirection,
+  ): IDBRequest<IDBCursor | null> {
+    const self = this;
+    const req = new EventTarget() as IDBRequest<IDBCursor | null>;
+    const cursor: IDBCursor = {
+      source: this as unknown as IDBObjectStore,
+      direction: 'next',
+      key: 2,
+      primaryKey: 2,
+      request: req,
+      advance: () => null as unknown as IDBRequest<IDBCursor | null>,
+      continue: () => {
+        self.openKeyCursorCalls += 1;
+        const nextReq = new EventTarget() as IDBRequest<IDBCursor | null>;
+        (nextReq as { result: IDBCursor | null }).result =
+          self.openKeyCursorCalls < 2 ? cursor : null;
+        setTimeout(() => nextReq.dispatchEvent(new Event('success')), 0);
+        return nextReq;
+      },
+      continuePrimaryKey: () => null as unknown as IDBRequest<IDBCursor | null>,
+      delete: () => null as unknown as IDBRequest<undefined>,
+      update: () => null as unknown as IDBRequest<IDBValidKey>,
+    };
+    (req as { result: IDBCursor | null }).result = cursor;
+    setTimeout(() => req.dispatchEvent(new Event('success')), 0);
+    return req;
+  }
+}
+
+test('ObjectStoreAdapter.add resolves with key', async () => {
+  const adapter = new ObjectStoreAdapter(new MockIDBObjectStore());
+  const key = await adapter.add({ id: 1 });
+  assert.equal(key, 1);
+});
+
+test('ObjectStoreAdapter.clear resolves with undefined', async () => {
+  const adapter = new ObjectStoreAdapter(new MockIDBObjectStore());
+  const result = await adapter.clear();
+  assert.equal(result, undefined);
+});
+
+test('ObjectStoreAdapter.count returns number', async () => {
+  const adapter = new ObjectStoreAdapter(new MockIDBObjectStore());
+  const n = await adapter.count();
+  assert.equal(n, 3);
+});
+
+test('ObjectStoreAdapter.delete resolves with undefined', async () => {
+  const adapter = new ObjectStoreAdapter(new MockIDBObjectStore());
+  const result = await adapter.delete(1);
+  assert.equal(result, undefined);
+});
+
+test('ObjectStoreAdapter.get returns value', async () => {
+  const adapter = new ObjectStoreAdapter(new MockIDBObjectStore());
+  const value = await adapter.get(1);
+  assert.deepEqual(value, { id: 1, name: 'test' });
+});
+
+test('ObjectStoreAdapter.getAll returns array', async () => {
+  const adapter = new ObjectStoreAdapter(new MockIDBObjectStore());
+  const arr = await adapter.getAll();
+  assert.deepEqual(arr, [{ id: 1 }, { id: 2 }]);
+});
+
+test('ObjectStoreAdapter.getAllKeys returns keys', async () => {
+  const adapter = new ObjectStoreAdapter(new MockIDBObjectStore());
+  const keys = await adapter.getAllKeys();
+  assert.deepEqual(keys, [1, 2, 3]);
+});
+
+test('ObjectStoreAdapter.getKey returns single key', async () => {
+  const adapter = new ObjectStoreAdapter(new MockIDBObjectStore());
+  const key = await adapter.getKey(1);
+  assert.equal(key, 1);
+});
+
+test('ObjectStoreAdapter.put resolves with key', async () => {
+  const adapter = new ObjectStoreAdapter(new MockIDBObjectStore());
+  const key = await adapter.put({ id: 42 });
+  assert.equal(key, 42);
+});
+
+test('ObjectStoreAdapter.createIndex returns IndexAdapter', () => {
+  const adapter = new ObjectStoreAdapter(new MockIDBObjectStore());
+  const index = adapter.createIndex('byName', 'name');
+  assert.ok(index instanceof IndexAdapter);
+  assert.equal(index.name, 'byName');
+});
+
+test('ObjectStoreAdapter.index returns IndexAdapter', () => {
+  const adapter = new ObjectStoreAdapter(new MockIDBObjectStore());
+  const index = adapter.index('byName');
+  assert.ok(index instanceof IndexAdapter);
+  assert.equal(index.name, 'byName');
+});
+
+test('ObjectStoreAdapter.indexNames returns string array', () => {
+  const adapter = new ObjectStoreAdapter(new MockIDBObjectStore());
+  assert.deepEqual(adapter.indexNames, ['byName']);
+});
+
+test('ObjectStoreAdapter.openCursor yields Cursor entries', async () => {
+  const store = new MockIDBObjectStore();
+  const adapter = new ObjectStoreAdapter(store);
+  const values: unknown[] = [];
+  /* eslint-disable no-restricted-syntax -- for-await-of is required for async iterable */
+  for await (const cursor of adapter.openCursor()) {
+    values.push(cursor.value);
+  }
+  assert.equal(values.length, 2);
+  assert.deepEqual(values[0], { id: 1 });
+});
+
+test('ObjectStoreAdapter.openKeyCursor yields Cursor entries', async () => {
+  const store = new MockIDBObjectStore();
+  const adapter = new ObjectStoreAdapter(store);
+  const keys: IDBValidKey[] = [];
+  /* eslint-disable no-restricted-syntax -- for-await-of is required for async iterable */
+  for await (const cursor of adapter.openKeyCursor()) {
+    keys.push(cursor.key!);
+  }
+  assert.equal(keys.length, 2);
+  assert.equal(keys[0], 2);
+});
+
+test('ObjectStoreAdapter.from creates adapter', () => {
+  const store = new MockIDBObjectStore();
+  const adapter = ObjectStoreAdapter.from(store);
+  assert.ok(adapter instanceof ObjectStoreAdapter);
+  assert.equal(adapter.name, 'testStore');
+  assert.equal(adapter.autoIncrement, false);
+});
+
+test('ObjectStoreAdapter yields Cursor instances', async () => {
+  const store = new MockIDBObjectStore();
+  const adapter = new ObjectStoreAdapter(store);
+  /* eslint-disable no-restricted-syntax -- for-await-of is required for async iterable */
+  for await (const cursor of adapter.openCursor()) {
+    assert.ok(cursor instanceof Cursor);
+  }
+});

--- a/tests/IDBObjectStore.test.ts
+++ b/tests/IDBObjectStore.test.ts
@@ -68,22 +68,22 @@ class MockIDBObjectStore implements IDBObjectStore {
   deleteIndex(_name: string): void {}
 
   get(_query: IDBValidKey | IDBKeyRange): IDBRequest<unknown> {
-    return createRequest({ id: 1, name: 'test' });
+    return createRequest<unknown>({ id: 1, name: 'test' });
   }
 
   getAll(_query?: IDBValidKey | IDBKeyRange | null, _count?: number): IDBRequest<unknown[]> {
-    return createRequest([{ id: 1 }, { id: 2 }]);
+    return createRequest<unknown[]>([{ id: 1 }, { id: 2 }]);
   }
 
   getAllKeys(
     _query?: IDBValidKey | IDBKeyRange | null,
     _count?: number,
   ): IDBRequest<IDBValidKey[]> {
-    return createRequest([1, 2, 3] as IDBValidKey[]);
+    return createRequest<IDBValidKey[]>([1, 2, 3] as IDBValidKey[]);
   }
 
   getKey(_query: IDBValidKey | IDBKeyRange): IDBRequest<IDBValidKey | undefined> {
-    return createRequest(1 as IDBValidKey);
+    return createRequest<IDBValidKey | undefined>(1 as IDBValidKey);
   }
 
   index(name: string): IDBIndex {

--- a/tests/IDBTransaction.test.ts
+++ b/tests/IDBTransaction.test.ts
@@ -54,22 +54,22 @@ class MockIDBObjectStore implements IDBObjectStore {
   deleteIndex(_name: string): void {}
 
   get(_query: IDBValidKey | IDBKeyRange): IDBRequest<unknown> {
-    return createRequest(undefined);
+    return createRequest<unknown>(undefined);
   }
 
   getAll(_query?: IDBValidKey | IDBKeyRange | null, _count?: number): IDBRequest<unknown[]> {
-    return createRequest([]);
+    return createRequest<unknown[]>([]);
   }
 
   getAllKeys(
     _query?: IDBValidKey | IDBKeyRange | null,
     _count?: number,
   ): IDBRequest<IDBValidKey[]> {
-    return createRequest([]);
+    return createRequest<IDBValidKey[]>([]);
   }
 
   getKey(_query: IDBValidKey | IDBKeyRange): IDBRequest<IDBValidKey | undefined> {
-    return createRequest(undefined);
+    return createRequest<IDBValidKey | undefined>(undefined);
   }
 
   index(_name: string): IDBIndex {
@@ -80,14 +80,14 @@ class MockIDBObjectStore implements IDBObjectStore {
     _query?: IDBValidKey | IDBKeyRange | null,
     _direction?: IDBCursorDirection,
   ): IDBRequest<IDBCursorWithValue | null> {
-    return createRequest(null);
+    return createRequest<IDBCursorWithValue | null>(null);
   }
 
   openKeyCursor(
     _query?: IDBValidKey | IDBKeyRange | null,
     _direction?: IDBCursorDirection,
   ): IDBRequest<IDBCursor | null> {
-    return createRequest(null);
+    return createRequest<IDBCursor | null>(null);
   }
 
   put(_value: unknown, _key?: IDBValidKey): IDBRequest<IDBValidKey> {

--- a/tests/IDBTransaction.test.ts
+++ b/tests/IDBTransaction.test.ts
@@ -1,0 +1,172 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { TransactionAdapter } from '../IDBTransaction';
+import { ObjectStoreAdapter } from '../IDBObjectStore';
+
+function makeDomStringList(items: string[]): DOMStringList {
+  return {
+    length: items.length,
+    item: (index: number) => items[index] ?? null,
+    contains: (str: string) => items.includes(str),
+    [Symbol.iterator]: items[Symbol.iterator].bind(items),
+  } as unknown as DOMStringList;
+}
+
+function createRequest<T>(result: T): IDBRequest<T> {
+  const req = new EventTarget() as IDBRequest<T>;
+  (req as { result: T }).result = result;
+  (req as { error: unknown }).error = null;
+  setTimeout(() => req.dispatchEvent(new Event('success')), 0);
+  return req;
+}
+
+class MockIDBObjectStore implements IDBObjectStore {
+  name = 'mockStore';
+
+  keyPath: string | string[] = 'id';
+
+  indexNames = makeDomStringList([]);
+
+  autoIncrement = false;
+
+  transaction = {} as IDBTransaction;
+
+  add(_value: unknown, _key?: IDBValidKey): IDBRequest<IDBValidKey> {
+    return createRequest(1 as IDBValidKey);
+  }
+
+  clear(): IDBRequest<undefined> {
+    return createRequest(undefined);
+  }
+
+  count(_query?: IDBValidKey | IDBKeyRange): IDBRequest<number> {
+    return createRequest(0);
+  }
+
+  createIndex(_name: string, _keyPath: string | string[], _options?: IDBIndexParameters): IDBIndex {
+    return {} as IDBIndex;
+  }
+
+  delete(_query: IDBValidKey | IDBKeyRange): IDBRequest<undefined> {
+    return createRequest(undefined);
+  }
+
+  deleteIndex(_name: string): void {}
+
+  get(_query: IDBValidKey | IDBKeyRange): IDBRequest<unknown> {
+    return createRequest(undefined);
+  }
+
+  getAll(_query?: IDBValidKey | IDBKeyRange | null, _count?: number): IDBRequest<unknown[]> {
+    return createRequest([]);
+  }
+
+  getAllKeys(
+    _query?: IDBValidKey | IDBKeyRange | null,
+    _count?: number,
+  ): IDBRequest<IDBValidKey[]> {
+    return createRequest([]);
+  }
+
+  getKey(_query: IDBValidKey | IDBKeyRange): IDBRequest<IDBValidKey | undefined> {
+    return createRequest(undefined);
+  }
+
+  index(_name: string): IDBIndex {
+    return {} as IDBIndex;
+  }
+
+  openCursor(
+    _query?: IDBValidKey | IDBKeyRange | null,
+    _direction?: IDBCursorDirection,
+  ): IDBRequest<IDBCursorWithValue | null> {
+    return createRequest(null);
+  }
+
+  openKeyCursor(
+    _query?: IDBValidKey | IDBKeyRange | null,
+    _direction?: IDBCursorDirection,
+  ): IDBRequest<IDBCursor | null> {
+    return createRequest(null);
+  }
+
+  put(_value: unknown, _key?: IDBValidKey): IDBRequest<IDBValidKey> {
+    return createRequest(1 as IDBValidKey);
+  }
+}
+
+class MockIDBTransaction extends EventTarget implements IDBTransaction {
+  db = {} as IDBDatabase;
+
+  durability: IDBTransactionDurability = 'default';
+
+  error: DOMException | null = null;
+
+  mode: IDBTransactionMode = 'readonly';
+
+  objectStoreNames: DOMStringList;
+
+  onabort: ((this: IDBTransaction, ev: Event) => unknown) | null = null;
+
+  oncomplete: ((this: IDBTransaction, ev: Event) => unknown) | null = null;
+
+  onerror: ((this: IDBTransaction, ev: Event) => unknown) | null = null;
+
+  private readonly storeNames: string[];
+
+  constructor(storeNames: string[]) {
+    super();
+    this.storeNames = storeNames;
+    this.objectStoreNames = makeDomStringList(storeNames);
+  }
+
+  objectStore(name: string): IDBObjectStore {
+    if (!this.storeNames.includes(name)) {
+      throw new DOMException(`No objectStore named ${name} in this transaction`, 'NotFoundError');
+    }
+    const store = new MockIDBObjectStore();
+    store.name = name;
+    return store as unknown as IDBObjectStore;
+  }
+
+  commit(): void {}
+
+  abort(): void {}
+}
+
+test('TransactionAdapter.objectStoreNames returns string array', () => {
+  const tx = new MockIDBTransaction(['users', 'posts']);
+  const adapter = new TransactionAdapter(tx);
+  assert.deepEqual(adapter.objectStoreNames, ['users', 'posts']);
+});
+
+test('TransactionAdapter.objectStore returns ObjectStoreAdapter', () => {
+  const tx = new MockIDBTransaction(['users']);
+  const adapter = new TransactionAdapter(tx);
+  const store = adapter.objectStore('users');
+  assert.ok(store instanceof ObjectStoreAdapter);
+  assert.equal(store.name, 'users');
+});
+
+test('TransactionAdapter exposes db, mode, durability, error', () => {
+  const tx = new MockIDBTransaction(['items']);
+  const adapter = new TransactionAdapter(tx);
+  assert.equal(adapter.db, tx.db);
+  assert.equal(adapter.mode, 'readonly');
+  assert.equal(adapter.durability, 'default');
+  assert.equal(adapter.error, null);
+});
+
+test('TransactionAdapter.from creates adapter', () => {
+  const tx = new MockIDBTransaction(['a', 'b']);
+  const adapter = TransactionAdapter.from(tx);
+  assert.ok(adapter instanceof TransactionAdapter);
+  assert.deepEqual(adapter.objectStoreNames, ['a', 'b']);
+});
+
+test('TransactionAdapter.commit and abort are callable', () => {
+  const tx = new MockIDBTransaction([]);
+  const adapter = new TransactionAdapter(tx);
+  assert.doesNotThrow(() => adapter.commit());
+  assert.doesNotThrow(() => adapter.abort());
+});

--- a/tests/adoptRequest.test.ts
+++ b/tests/adoptRequest.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
-import { adoptRequest } from '../adoptRequest';
+import { AdoptRequest } from '../adoptRequest';
 
 class MockRequest<T> extends EventTarget {
   result!: T;
@@ -10,7 +10,7 @@ class MockRequest<T> extends EventTarget {
 
 test('adoptRequest resolves on success with request.result', async () => {
   const request = new MockRequest<number>();
-  const promise = adoptRequest<number>(request as IDBRequest<number>);
+  const promise = new AdoptRequest<number>(request as IDBRequest<number>).toPromise();
   request.result = 42;
   request.dispatchEvent(new Event('success'));
 
@@ -23,7 +23,7 @@ test('adoptRequest rejects on error with request.error', async () => {
   const error = new Error('boom');
   request.error = error;
 
-  const promise = adoptRequest<number>(request as IDBRequest<number>);
+  const promise = new AdoptRequest<number>(request as IDBRequest<number>).toPromise();
   request.dispatchEvent(new Event('error'));
 
   await assert.rejects(promise, error);

--- a/tests/adoptRequest.test.ts
+++ b/tests/adoptRequest.test.ts
@@ -1,0 +1,30 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { adoptRequest } from '../adoptRequest';
+
+class MockRequest<T> extends EventTarget {
+  result!: T;
+
+  error: unknown = null;
+}
+
+test('adoptRequest resolves on success with request.result', async () => {
+  const request = new MockRequest<number>();
+  const promise = adoptRequest<number>(request as IDBRequest<number>);
+  request.result = 42;
+  request.dispatchEvent(new Event('success'));
+
+  const result = await promise;
+  assert.equal(result, 42);
+});
+
+test('adoptRequest rejects on error with request.error', async () => {
+  const request = new MockRequest<number>();
+  const error = new Error('boom');
+  request.error = error;
+
+  const promise = adoptRequest<number>(request as IDBRequest<number>);
+  request.dispatchEvent(new Event('error'));
+
+  await assert.rejects(promise, error);
+});

--- a/tests/cursor.test.ts
+++ b/tests/cursor.test.ts
@@ -1,0 +1,290 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { Cursor } from '../cursor';
+
+class MockCursor extends EventTarget implements IDBCursor {
+  source: IDBObjectStore | IDBIndex;
+
+  direction: IDBCursorDirection = 'next';
+
+  key: IDBValidKey = 1;
+
+  primaryKey: IDBValidKey = 1;
+
+  request: IDBRequest<IDBCursor | IDBCursorWithValue | null>;
+
+  protected _value: unknown;
+
+  constructor(source: IDBObjectStore | IDBIndex, value?: unknown) {
+    super();
+    this.source = source;
+    this._value = value;
+    this.request = this.createRequest();
+  }
+
+  private createRequest(): IDBRequest<IDBCursor | IDBCursorWithValue | null> {
+    const request = new EventTarget() as IDBRequest<IDBCursor | IDBCursorWithValue | null>;
+    (request as { result: IDBCursor | IDBCursorWithValue | null }).result = this as unknown as IDBCursor;
+    (request as { error: unknown }).error = null;
+    return request as IDBRequest<IDBCursor | IDBCursorWithValue | null>;
+  }
+
+  advance(count: number): IDBRequest<IDBCursor | IDBCursorWithValue | null> {
+    const request = this.createRequest();
+    setTimeout(() => {
+      this.key = ((this.key as number) ?? 0) + count;
+      request.dispatchEvent(new Event('success'));
+    }, 0);
+    return request;
+  }
+
+  continue(key?: IDBValidKey): IDBRequest<IDBCursor | IDBCursorWithValue | null> {
+    const request = this.createRequest();
+    setTimeout(() => {
+      if (key !== undefined) {
+        this.key = key;
+      } else {
+        this.key = ((this.key as number) ?? 0) + 1;
+      }
+      request.dispatchEvent(new Event('success'));
+    }, 0);
+    return request;
+  }
+
+  continuePrimaryKey(
+    key: IDBValidKey,
+    primaryKey: IDBValidKey,
+  ): IDBRequest<IDBCursor | IDBCursorWithValue | null> {
+    const request = this.createRequest();
+    setTimeout(() => {
+      this.key = key;
+      this.primaryKey = primaryKey;
+      request.dispatchEvent(new Event('success'));
+    }, 0);
+    return request;
+  }
+
+  delete(): IDBRequest<undefined> {
+    const request = new EventTarget() as IDBRequest<IDBValidKey>;
+    const deletedKey = this.key;
+    setTimeout(() => {
+      (request as { result: IDBValidKey }).result = deletedKey;
+      request.dispatchEvent(new Event('success'));
+    }, 0);
+    return request as unknown as IDBRequest<undefined>;
+  }
+
+  update(value: unknown): IDBRequest<IDBValidKey> {
+    const request = new EventTarget() as IDBRequest<IDBValidKey>;
+    this._value = value;
+    const updatedKey = this.key;
+    setTimeout(() => {
+      (request as { result: IDBValidKey }).result = updatedKey!;
+      request.dispatchEvent(new Event('success'));
+    }, 0);
+    return request as IDBRequest<IDBValidKey>;
+  }
+}
+
+class MockCursorWithValue extends MockCursor implements IDBCursorWithValue {
+  key: IDBValidKey = 1;
+
+  constructor(
+    source: IDBObjectStore | IDBIndex,
+    public value: unknown,
+  ) {
+    super(source, value);
+  }
+
+  override update(value: unknown): IDBRequest<IDBValidKey> {
+    const request = new EventTarget() as IDBRequest<IDBValidKey>;
+    this.value = value;
+    this._value = value;
+    const updatedKey = this.key;
+    setTimeout(() => {
+      (request as { result: IDBValidKey }).result = updatedKey;
+      request.dispatchEvent(new Event('success'));
+    }, 0);
+    return request as IDBRequest<IDBValidKey>;
+  }
+}
+
+class MockDOMStringList extends Array<string> implements DOMStringList {
+  contains(str: string): boolean {
+    return this.includes(str);
+  }
+
+  item(index: number): string | null {
+    return this[index] ?? null;
+  }
+}
+
+class MockObjectStore extends EventTarget implements IDBObjectStore {
+  name = 'testStore';
+
+  keyPath: string | string[] | null = null;
+
+  indexNames = new MockDOMStringList();
+
+  autoIncrement = false;
+
+  transaction = {} as IDBTransaction;
+
+  add(): IDBRequest<IDBValidKey> {
+    throw new Error('Not implemented');
+  }
+
+  clear(): IDBRequest<undefined> {
+    throw new Error('Not implemented');
+  }
+
+  count(query?: IDBValidKey | IDBKeyRange): IDBRequest<number> {
+    throw new Error('Not implemented');
+  }
+
+  createIndex(): IDBIndex {
+    throw new Error('Not implemented');
+  }
+
+  delete(): IDBRequest<undefined> {
+    throw new Error('Not implemented');
+  }
+
+  deleteIndex(): void {
+    throw new Error('Not implemented');
+  }
+
+  get(): IDBRequest<unknown> {
+    throw new Error('Not implemented');
+  }
+
+  getAll(): IDBRequest<unknown[]> {
+    throw new Error('Not implemented');
+  }
+
+  getAllKeys(): IDBRequest<IDBValidKey[]> {
+    throw new Error('Not implemented');
+  }
+
+  getKey(): IDBRequest<IDBValidKey | undefined> {
+    throw new Error('Not implemented');
+  }
+
+  index(): IDBIndex {
+    throw new Error('Not implemented');
+  }
+
+  openCursor(): IDBRequest<IDBCursorWithValue | null> {
+    throw new Error('Not implemented');
+  }
+
+  openKeyCursor(): IDBRequest<IDBCursor | null> {
+    throw new Error('Not implemented');
+  }
+
+  put(): IDBRequest<IDBValidKey> {
+    throw new Error('Not implemented');
+  }
+}
+
+test('Cursor exposes cursor properties', () => {
+  const store = new MockObjectStore();
+  const cursor = new MockCursor(store);
+  const wrapper = new Cursor(cursor as IDBCursor);
+
+  assert.equal(wrapper.source, store);
+  assert.equal(wrapper.direction, 'next');
+  assert.equal(wrapper.key, 1);
+  assert.equal(wrapper.primaryKey, 1);
+  assert.equal(wrapper.request, cursor.request);
+});
+
+test('Cursor exposes value for IDBCursorWithValue', () => {
+  const store = new MockObjectStore();
+  const cursor = new MockCursorWithValue(store, { id: 1, name: 'test' });
+  const wrapper = new Cursor(cursor);
+
+  assert.deepEqual(wrapper.value, { id: 1, name: 'test' });
+});
+
+test('Cursor.advance() moves cursor forward', async () => {
+  const store = new MockObjectStore();
+  const cursor = new MockCursor(store);
+  cursor.key = 1;
+  const wrapper = new Cursor(cursor as IDBCursor);
+
+  const result = await wrapper.advance(3);
+
+  assert.equal(result, cursor);
+  assert.equal(cursor.key, 4);
+});
+
+test('Cursor.continue() moves cursor to next position', async () => {
+  const store = new MockObjectStore();
+  const cursor = new MockCursor(store);
+  cursor.key = 1;
+  const wrapper = new Cursor(cursor as IDBCursor);
+
+  const result = await wrapper.continue();
+
+  assert.equal(result, cursor);
+  assert.equal(cursor.key, 2);
+});
+
+test('Cursor.continue(key) moves cursor to specific key', async () => {
+  const store = new MockObjectStore();
+  const cursor = new MockCursor(store);
+  cursor.key = 1;
+  const wrapper = new Cursor(cursor as IDBCursor);
+
+  const result = await wrapper.continue(5);
+
+  assert.equal(result, cursor);
+  assert.equal(cursor.key, 5);
+});
+
+test('Cursor.continuePrimaryKey() moves cursor to key and primaryKey', async () => {
+  const store = new MockObjectStore();
+  const cursor = new MockCursor(store);
+  cursor.key = 1;
+  cursor.primaryKey = 1;
+  const wrapper = new Cursor(cursor as IDBCursor);
+
+  const result = await wrapper.continuePrimaryKey(10, 20);
+
+  assert.equal(result, cursor);
+  assert.equal(cursor.key, 10);
+  assert.equal(cursor.primaryKey, 20);
+});
+
+test('Cursor.delete() deletes record and returns key', async () => {
+  const store = new MockObjectStore();
+  const cursor = new MockCursor(store);
+  cursor.key = 42;
+  const wrapper = new Cursor(cursor as IDBCursor);
+
+  const deletedKey = await wrapper.delete();
+
+  assert.equal(deletedKey, 42);
+});
+
+test('Cursor.update() updates record and returns key', async () => {
+  const store = new MockObjectStore();
+  const cursor = new MockCursorWithValue(store, { id: 1 });
+  cursor.key = 42;
+  const wrapper = new Cursor(cursor);
+
+  const updatedKey = await wrapper.update({ id: 1, name: 'updated' });
+
+  assert.equal(updatedKey, 42);
+  assert.deepEqual(cursor.value, { id: 1, name: 'updated' });
+});
+
+test('Cursor.from() creates Cursor instance', () => {
+  const store = new MockObjectStore();
+  const cursor = new MockCursor(store);
+  const wrapper = Cursor.from(cursor as IDBCursor);
+
+  assert.ok(wrapper instanceof Cursor);
+  assert.equal(wrapper.source, store);
+});

--- a/tests/on.test.ts
+++ b/tests/on.test.ts
@@ -1,0 +1,49 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { on } from '../on';
+
+class TestErrorEvent extends Event {
+  error: unknown;
+
+  constructor(error: unknown) {
+    super('error');
+    this.error = error;
+  }
+}
+
+test('on yields events in order', async () => {
+  const target = new EventTarget();
+  const iterator = on<Event>(target, 'data');
+
+  const nextOne = iterator.next();
+  target.dispatchEvent(new Event('data'));
+  const resultOne = await nextOne;
+
+  assert.equal(resultOne.done, false);
+  assert.equal(resultOne.value.type, 'data');
+
+  await iterator.return();
+});
+
+test('on rejects pending next on error event', async () => {
+  const target = new EventTarget();
+  const iterator = on<Event>(target, 'data');
+  const error = new Error('boom');
+
+  const pending = iterator.next();
+  target.dispatchEvent(new TestErrorEvent(error));
+
+  await assert.rejects(pending, error);
+});
+
+test('on rejects pending next on abort', async () => {
+  const target = new EventTarget();
+  const controller = new AbortController();
+  const iterator = on<Event>(target, 'data', { signal: controller.signal });
+  const error = new Error('stop');
+
+  const pending = iterator.next();
+  controller.abort(error);
+
+  await assert.rejects(pending, error);
+});

--- a/tests/on.test.ts
+++ b/tests/on.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
-import { on } from '../on';
+import { On } from '../on';
 
 class TestErrorEvent extends Event {
   error: unknown;
@@ -13,7 +13,7 @@ class TestErrorEvent extends Event {
 
 test('on yields events in order', async () => {
   const target = new EventTarget();
-  const iterator = on<Event>(target, 'data');
+  const iterator = new On<Event>(target, 'data');
 
   const nextOne = iterator.next();
   target.dispatchEvent(new Event('data'));
@@ -27,7 +27,7 @@ test('on yields events in order', async () => {
 
 test('on rejects pending next on error event', async () => {
   const target = new EventTarget();
-  const iterator = on<Event>(target, 'data');
+  const iterator = new On<Event>(target, 'data');
   const error = new Error('boom');
 
   const pending = iterator.next();
@@ -39,7 +39,7 @@ test('on rejects pending next on error event', async () => {
 test('on rejects pending next on abort', async () => {
   const target = new EventTarget();
   const controller = new AbortController();
-  const iterator = on<Event>(target, 'data', { signal: controller.signal });
+  const iterator = new On<Event>(target, 'data', { signal: controller.signal });
   const error = new Error('stop');
 
   const pending = iterator.next();

--- a/tests/once.test.ts
+++ b/tests/once.test.ts
@@ -1,0 +1,41 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { once } from '../once';
+
+class TestErrorEvent extends Event {
+  error: unknown;
+
+  constructor(error: unknown) {
+    super('error');
+    this.error = error;
+  }
+}
+
+test('once resolves with event data', async () => {
+  const target = new EventTarget();
+  const promise = once<Event>(target, 'ready');
+  target.dispatchEvent(new Event('ready'));
+
+  const event = await promise;
+  assert.equal(event.type, 'ready');
+});
+
+test('once rejects on error event', async () => {
+  const target = new EventTarget();
+  const error = new Error('fail');
+  const promise = once<Event>(target, 'ready');
+  target.dispatchEvent(new TestErrorEvent(error));
+
+  await assert.rejects(promise, error);
+});
+
+test('once rejects on abort with abort reason', async () => {
+  const target = new EventTarget();
+  const controller = new AbortController();
+  const error = new Error('stop');
+  const promise = once<Event>(target, 'ready', { signal: controller.signal });
+
+  controller.abort(error);
+
+  await assert.rejects(promise, error);
+});

--- a/tests/once.test.ts
+++ b/tests/once.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
-import { once } from '../once';
+import { Once } from '../once';
 
 class TestErrorEvent extends Event {
   error: unknown;
@@ -13,7 +13,7 @@ class TestErrorEvent extends Event {
 
 test('once resolves with event data', async () => {
   const target = new EventTarget();
-  const promise = once<Event>(target, 'ready');
+  const promise = new Once<Event>(target, 'ready').listen();
   target.dispatchEvent(new Event('ready'));
 
   const event = await promise;
@@ -23,7 +23,7 @@ test('once resolves with event data', async () => {
 test('once rejects on error event', async () => {
   const target = new EventTarget();
   const error = new Error('fail');
-  const promise = once<Event>(target, 'ready');
+  const promise = new Once<Event>(target, 'ready').listen();
   target.dispatchEvent(new TestErrorEvent(error));
 
   await assert.rejects(promise, error);
@@ -33,7 +33,7 @@ test('once rejects on abort with abort reason', async () => {
   const target = new EventTarget();
   const controller = new AbortController();
   const error = new Error('stop');
-  const promise = once<Event>(target, 'ready', { signal: controller.signal });
+  const promise = new Once<Event>(target, 'ready', { signal: controller.signal }).listen();
 
   controller.abort(error);
 

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "files": [
+    "./adoptRequest.ts",
+    "./index.ts",
+    "./index.d.ts",
+    "./on.ts",
+    "./once.ts",
+    "./tests/adoptRequest.test.ts",
+    "./tests/on.test.ts",
+    "./tests/once.test.ts"
+  ]
+}

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -4,6 +4,7 @@
     "./adoptRequest.ts",
     "./abort.ts",
     "./cursor.ts",
+    "./IDBIndex.ts",
     "./index.ts",
     "./index.d.ts",
     "./on.ts",
@@ -12,6 +13,7 @@
     "./types.d.ts",
     "./tests/adoptRequest.test.ts",
     "./tests/cursor.test.ts",
+    "./tests/IDBIndex.test.ts",
     "./tests/on.test.ts",
     "./tests/once.test.ts"
   ]

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -2,11 +2,16 @@
   "extends": "./tsconfig.json",
   "files": [
     "./adoptRequest.ts",
+    "./abort.ts",
+    "./cursor.ts",
     "./index.ts",
     "./index.d.ts",
     "./on.ts",
     "./once.ts",
+    "./types.ts",
+    "./types.d.ts",
     "./tests/adoptRequest.test.ts",
+    "./tests/cursor.test.ts",
     "./tests/on.test.ts",
     "./tests/once.test.ts"
   ]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022", "DOM"],
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["*.ts", "*.d.ts", "tests/**/*.ts"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "ESNext",
     "moduleResolution": "Bundler",
     "lib": ["ES2022", "DOM"],
+    "types": ["node"],
     "strict": true,
     "skipLibCheck": true,
     "noEmit": true

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,0 +1,19 @@
+export type OnceOptions = {
+  signal?: AbortSignal;
+};
+
+export type OnOptions = {
+  signal?: AbortSignal;
+};
+
+export type IDBTarget = IDBOpenDBRequest | IDBRequest | IDBTransaction | IDBDatabase;
+
+export type IDBEventMap<T> = T extends IDBOpenDBRequest
+  ? IDBOpenDBRequestEventMap
+  : T extends IDBRequest
+    ? IDBRequestEventMap
+    : T extends IDBTransaction
+      ? IDBTransactionEventMap
+      : T extends IDBDatabase
+        ? IDBDatabaseEventMap
+        : never;

--- a/types.ts
+++ b/types.ts
@@ -1,0 +1,19 @@
+export type OnceOptions = {
+  signal?: AbortSignal;
+};
+
+export type OnOptions = {
+  signal?: AbortSignal;
+};
+
+export type IDBTarget = IDBOpenDBRequest | IDBRequest | IDBTransaction | IDBDatabase;
+
+export type IDBEventMap<T> = T extends IDBOpenDBRequest
+  ? IDBOpenDBRequestEventMap
+  : T extends IDBRequest
+    ? IDBRequestEventMap
+    : T extends IDBTransaction
+      ? IDBTransactionEventMap
+      : T extends IDBDatabase
+        ? IDBDatabaseEventMap
+        : never;


### PR DESCRIPTION
## Overview

Full TypeScript reimplementation of the IndexedDB adoption layer. Replaces the existing JS prototype with a typed, tested, and linted library that covers the entire IDB API surface as requested in issues #1–#8.

Closes #1
Closes #2
Closes #4
Closes #5
Closes #6
Closes #7
Closes #8

---

## Key differences from current `main`

| | Current `main` | This PR |
|---|---|---|
| Language | JavaScript | TypeScript 5.7 (strict) |
| Output | Browser demo (`index.html`) | Library (no build step, `.ts` exports) |
| Tests | None | 53 tests, `node:test` runner |
| Linting | None | ESLint 8, airbnb-base + TS rules |
| Formatting | None | Prettier 3 |
| IDB coverage | `IDBRequest`, `IDBDatabase` (partial) | Full: all 8 interfaces |

---

## Implemented adapters

### `Once<T>` / `On<T>` — closes #1 (`on.ts`, `once.ts`)
- `Once<TEvent>` — `Promise<TEvent>` from a single EventTarget event; supports `AbortSignal`
- `On<TEvent>` — `AsyncIterableIterator<TEvent>` for continuous event streams; buffers events, handles errors and abort

### `AdoptRequest<T>` — closes #2 (`adoptRequest.ts`)
- Converts `IDBRequest<T>` to `Promise<T>`; uses `AbortController` to clean up listeners on both resolve and reject

### `Cursor` — closes #4 (`cursor.ts`)
- Wraps `IDBCursor | IDBCursorWithValue`
- Promisifies: `advance`, `continue`, `continuePrimaryKey`, `delete`, `update`

### `IndexAdapter` — closes #5 (`IDBIndex.ts`)
- Wraps `IDBIndex`
- Promisifies: `get`, `getAll`, `getAllKeys`, `getKey`, `count`
- AsyncGenerators: `openCursor`, `openKeyCursor` → `AsyncGenerator<Cursor>`

### `ObjectStoreAdapter` — closes #6 (`IDBObjectStore.ts`)
- Wraps `IDBObjectStore`
- Promisifies: `add`, `clear`, `count`, `delete`, `get`, `getAll`, `getAllKeys`, `getKey`, `put`
- AsyncGenerators: `openCursor`, `openKeyCursor` → `AsyncGenerator<Cursor>`
- Adapts: `createIndex`, `index` → `IndexAdapter`

### `TransactionAdapter` — closes #7 (`IDBTransaction.ts`)
- Wraps `IDBTransaction`
- `objectStoreNames: DOMStringList` → `string[]`
- `objectStore(name)` → `ObjectStoreAdapter`

### `DatabaseAdapter` — closes #8 (`IDBDatabase.ts`)
- Wraps `IDBDatabase`
- `createObjectStore(...)` → `ObjectStoreAdapter`
- `transaction(...)` → `TransactionAdapter`
- `objectStoreNames: DOMStringList` → `string[]`

---

## Architecture — no circular dependencies

```
DatabaseAdapter
  └─ createObjectStore()    → ObjectStoreAdapter
  └─ transaction()          → TransactionAdapter
       └─ objectStore()     → ObjectStoreAdapter
            └─ createIndex() / index() → IndexAdapter
                 └─ openCursor()       → AsyncGenerator<Cursor>
                      └─ Cursor ← AdoptRequest
```

Cross-references that stay as raw DOM types to break potential cycles:
`ObjectStoreAdapter.transaction → IDBTransaction`,
`TransactionAdapter.db → IDBDatabase`,
`IndexAdapter.objectStore → IDBObjectStore`

---

## Tests — 53/53 pass

| File | Tests |
|------|-------|
| `tests/adoptRequest.test.ts` | 2 |
| `tests/cursor.test.ts` | 8 |
| `tests/IDBIndex.test.ts` | 9 |
| `tests/IDBObjectStore.test.ts` | 17 |
| `tests/IDBTransaction.test.ts` | 5 |
| `tests/IDBDatabase.test.ts` | 7 |
| `tests/on.test.ts` | 3 |
| `tests/once.test.ts` | 3 |
| **Total** | **53** |

Runner: Node.js built-in `node:test` + `assert/strict` — no external test dependencies.
Each file contains inline `Mock*` classes implementing full TypeScript DOM interfaces.

---

## Test plan

- [x] `npm test` — 53/53 pass (pre-commit git hook enforces this on every commit)
- [x] `npm run lint` — no ESLint warnings or errors
- [x] All adapter methods covered by unit tests
- [x] AsyncGenerator cursor iteration tested end-to-end (stops correctly at `null`)
- [x] `On` event buffering, error propagation and abort tested
- [x] `Once` immediate-abort edge case tested
- [x] Adapter return types verified (`createIndex` → `IndexAdapter`, `objectStore` → `ObjectStoreAdapter`, etc.)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)